### PR TITLE
adb: Use a default _SC_GETPW_R_SIZE_MAX size

### DIFF
--- a/patches/core/0016-adb-Use-a-default-_SC_GETPW_R_SIZE_MAX-size.patch
+++ b/patches/core/0016-adb-Use-a-default-_SC_GETPW_R_SIZE_MAX-size.patch
@@ -1,0 +1,31 @@
+From 8b43a0588b88ab4e48c114916788d68e5f1f99ac Mon Sep 17 00:00:00 2001
+From: Robert Yang <decatf@gmail.com>
+Date: Wed, 24 Oct 2018 09:48:40 -0400
+Subject: [PATCH] adb: Use a default _SC_GETPW_R_SIZE_MAX size
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+sysconf(_SC_GETPW_R_SIZE_MAX) may return −1 if there is no hard limit on
+the the buffer size. Some libc implementations such as musl don't define
+this limit and will return -1.
+
+Use a default buffer size to handle this case.
+---
+ adb/adb_utils.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/adb/adb_utils.cpp b/adb/adb_utils.cpp
+index b236fb39f..1c3bdf2d3 100644
+--- a/adb/adb_utils.cpp
++++ b/adb/adb_utils.cpp
+@@ -249,6 +249,9 @@ std::string adb_get_homedir_path() {
+     struct passwd pwent;
+     struct passwd* result;
+     int pwent_max = sysconf(_SC_GETPW_R_SIZE_MAX);
++    if (pwent_max == -1) {
++        pwent_max = 1024;
++    }
+     std::vector<char> buf(pwent_max);
+     int rc = getpwuid_r(getuid(), &pwent, buf.data(), buf.size(), &result);
+     if (rc == 0 && result) {


### PR DESCRIPTION
sysconf(_SC_GETPW_R_SIZE_MAX) may return −1 if there is no hard limit on
the the buffer size. Some libc implementations such as musl don't define
this limit and will return -1.

Use a default buffer size to handle this case.