### PR TITLE
Build Android sparse image (simg) tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Currently the following tools are supported:
 * adb
 * fastboot
 * mke2fs.android (required by fastboot)
+* simg2img, img2simg, append2simg
 
 The build system itself works quite well and is already being used for
 the Alpine Linux [android-tools package][alpine-linux] which I maintain.

--- a/vendor/CMakeLists.fastboot.txt
+++ b/vendor/CMakeLists.fastboot.txt
@@ -1,14 +1,3 @@
-add_library(libsparse STATIC
-	core/libsparse/backed_block.cpp
-	core/libsparse/output_file.cpp
-	core/libsparse/sparse.cpp
-	core/libsparse/sparse_crc32.cpp
-	core/libsparse/sparse_err.cpp
-	core/libsparse/sparse_read.cpp)
-
-target_include_directories(libsparse PUBLIC
-	core/libsparse/include core/base/include)
-
 add_library(libzip STATIC
 	core/libziparchive/zip_archive.cc)
 

--- a/vendor/CMakeLists.sparse.txt
+++ b/vendor/CMakeLists.sparse.txt
@@ -1,0 +1,25 @@
+add_library(libsparse STATIC
+	core/libsparse/backed_block.cpp
+	core/libsparse/output_file.cpp
+	core/libsparse/sparse.cpp
+	core/libsparse/sparse_crc32.cpp
+	core/libsparse/sparse_err.cpp
+	core/libsparse/sparse_read.cpp)
+
+target_include_directories(libsparse PUBLIC
+	core/libsparse/include core/base/include)
+
+add_executable(simg2img
+	core/libsparse/simg2img.cpp)
+target_link_libraries(simg2img
+	libsparse z libbase)
+
+add_executable(img2simg
+	core/libsparse/img2simg.cpp)
+target_link_libraries(img2simg
+	libsparse z libbase)
+
+add_executable(append2simg
+	core/libsparse/append2simg.cpp)
+target_link_libraries(append2simg
+	libsparse z libbase)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -26,6 +26,7 @@ if(EXISTS "${ANDROID_PATCH_DIR}/")
 endif()
 
 include(CMakeLists.adb.txt)
+include(CMakeLists.sparse.txt)
 include(CMakeLists.fastboot.txt)
 include(CMakeLists.mke2fs.txt)
 
@@ -36,4 +37,5 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Wno-attributes")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++2a -Wno-attributes")
 
 # Targets which should be installed by `make install`.
-install(TARGETS adb fastboot "${ANDROID_MKE2FS_NAME}" DESTINATION bin)
+install(TARGETS adb fastboot "${ANDROID_MKE2FS_NAME}"
+	simg2img img2simg append2simg DESTINATION bin)


### PR DESCRIPTION
libsparse is already built for fastboot, so building the simg tools only requires a few build rules to link the executables.

Adds the following tools:
  - simgtoimg
  - img2simg
  - append2simg

These tools are used to convert partition images to the sparse format (saving some space), and back.