### PR TITLE
Finish update to platform-tools-29.0.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "vendor/mkbootimg"]
 	path = vendor/mkbootimg
 	url = https://android.googlesource.com/platform/system/tools/mkbootimg
+[submodule "vendor/avb"]
+	path = vendor/avb
+	url = https://android.googlesource.com/platform/external/avb

--- a/patches/core/0001-Don-t-use-the-internal-glibc-header-sys-cdefs.h.patch
+++ b/patches/core/0001-Don-t-use-the-internal-glibc-header-sys-cdefs.h.patch
@@ -1,28 +1,39 @@
-From dd4eef22f736d27eb750d049447e43489ec4fe89 Mon Sep 17 00:00:00 2001
+From aa1a21801edbbe2d275c4eb85501af106b0a80e1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?S=C3=B6ren=20Tempel?= <soeren+git@soeren-tempel.net>
 Date: Sun, 22 Dec 2019 18:42:19 +0100
 Subject: [PATCH] Don't use the internal glibc header sys/cdefs.h
 
 This patch was created using sed(1) and ag(1) with the following script:
 
-	for file in $(ag -l __BEGIN_DECLS); do
+	for file in $(ag -l '__BEGIN_DECLS|sys/cdefs.h'); do
 		sed -i "${file}" \
 			-e 's/__BEGIN_DECLS/#ifdef __cplusplus\nextern "C" {\n#endif/g' \
 			-e 's/__END_DECLS/#ifdef __cplusplus\n}\n#endif/g' \
 			-e '/#include <sys\/cdefs.h>/d'
 	done
 
+Then remove garbage in core/liblog/log_portability.h.
+
 https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-<code>sys/cdefs.h</code>
 ---
+ base/include/android-base/endian.h            |  1 -
+ base/include/android-base/properties.h        |  1 -
+ debuggerd/include/debuggerd/client.h          |  1 -
  debuggerd/include/debuggerd/handler.h         |  9 +++++---
+ debuggerd/util.h                              |  1 -
  deprecated-adf/libadf/include/adf/adf.h       |  9 +++++---
  .../libadfhwc/include/adfhwc/adfhwc.h         |  9 +++++---
+ fs_mgr/fs_mgr_priv_boot_config.h              |  1 -
+ init/keychords.cpp                            |  1 -
+ init/reboot.cpp                               |  1 -
+ libasyncio/include/asyncio/AsyncIO.h          |  1 -
  libbacktrace/backtrace_testlib.h              |  9 +++++---
  libcutils/android_get_control_env.h           |  9 +++++---
  libcutils/include/cutils/android_reboot.h     |  9 +++++---
  libcutils/include/cutils/bitops.h             |  9 +++++---
  libcutils/include/cutils/klog.h               |  9 +++++---
  libcutils/include/cutils/partition_utils.h    |  9 +++++---
+ libcutils/include/cutils/properties.h         |  1 -
  libcutils/include/cutils/str_parms.h          |  9 +++++---
  libcutils/include/cutils/trace.h              |  9 +++++---
  libcutils/include/private/canned_fs_config.h  |  8 +++++--
@@ -34,31 +45,83 @@ https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-
  liblog/log_portability.h                      | 14 -------------
  liblog/logd_reader.h                          |  8 +++++--
  liblog/logger.h                               |  8 +++++--
+ libmemunreachable/Allocator.cpp               |  1 -
  libmemunreachable/Binder.cpp                  |  9 +++++---
  libmemunreachable/bionic.h                    |  9 +++++---
  .../include/memunreachable/memunreachable.h   |  9 +++++---
  libnetutils/include/netutils/ifc.h            |  9 +++++---
  .../packagelistparser/packagelistparser.h     |  8 +++++--
+ libpixelflinger/codeflinger/disassem.c        |  1 -
+ libpixelflinger/codeflinger/mips64_disassem.c |  1 -
+ libpixelflinger/codeflinger/mips_disassem.c   |  1 -
+ libprocessgroup/cgroup_map.h                  |  1 -
  .../cgrouprc/include/android/cgrouprc.h       |  8 +++++--
  .../include/processgroup/processgroup.h       |  9 +++++---
+ libprocessgroup/task_profiles.h               |  1 -
  libsuspend/autosuspend_ops.h                  |  8 +++++--
  libsuspend/include/suspend/autosuspend.h      |  9 +++++---
  libsync/include/android/sync.h                |  8 +++++--
  libsync/include/ndk/sync.h                    |  9 +++++---
  libsync/sw_sync.h                             |  8 +++++--
  libsystem/include/system/camera.h             |  9 +++++---
+ libsystem/include/system/radio.h              |  1 -
  libutils/Singleton_test.h                     |  9 +++++---
+ .../include/ziparchive/zip_archive.h          |  1 -
  llkd/include/llkd.h                           | 21 +++++++++++++------
+ llkd/libllkd.cpp                              |  1 -
  lmkd/include/liblmkd_utils.h                  |  9 +++++---
  lmkd/include/lmkd.h                           |  9 +++++---
+ lmkd/liblmkd_utils.c                          |  1 -
  lmkd/libpsi/include/psi/psi.h                 |  9 +++++---
+ lmkd/lmkd.c                                   |  1 -
  lmkd/statslog.h                               |  9 +++++---
+ logcat/logcat.cpp                             |  1 -
+ logcat/tests/logcat_test.cpp                  |  1 -
+ logd/LogBuffer.cpp                            |  1 -
+ logd/LogListener.cpp                          |  1 -
+ logd/LogUtils.h                               |  1 -
  logd/libaudit.h                               |  9 +++++---
  trusty/gatekeeper/trusty_gatekeeper_ipc.h     |  8 +++++--
  .../ipc/trusty_keymaster_ipc.h                |  8 +++++--
  .../storage/lib/include/trusty/lib/storage.h  |  8 +++++--
- 43 files changed, 261 insertions(+), 130 deletions(-)
+ 68 files changed, 261 insertions(+), 155 deletions(-)
 
+diff --git a/base/include/android-base/endian.h b/base/include/android-base/endian.h
+index 8fa6365ee..1e5cceb9a 100644
+--- a/base/include/android-base/endian.h
++++ b/base/include/android-base/endian.h
+@@ -19,7 +19,6 @@
+ /* A cross-platform equivalent of bionic's <sys/endian.h>. */
+ 
+ /* For __BIONIC__ and __GLIBC__ */
+-#include <sys/cdefs.h>
+ 
+ #if defined(__BIONIC__)
+ 
+diff --git a/base/include/android-base/properties.h b/base/include/android-base/properties.h
+index 31823df0a..be1a96b61 100644
+--- a/base/include/android-base/properties.h
++++ b/base/include/android-base/properties.h
+@@ -16,7 +16,6 @@
+ 
+ #pragma once
+ 
+-#include <sys/cdefs.h>
+ 
+ #include <chrono>
+ #include <limits>
+diff --git a/debuggerd/include/debuggerd/client.h b/debuggerd/include/debuggerd/client.h
+index b7284b08e..b85b6e542 100644
+--- a/debuggerd/include/debuggerd/client.h
++++ b/debuggerd/include/debuggerd/client.h
+@@ -17,7 +17,6 @@
+ #pragma once
+ 
+ #include <stdbool.h>
+-#include <sys/cdefs.h>
+ #include <unistd.h>
+ 
+ #include <android-base/unique_fd.h>
 diff --git a/debuggerd/include/debuggerd/handler.h b/debuggerd/include/debuggerd/handler.h
 index 7196e0ad4..9ba20db19 100644
 --- a/debuggerd/include/debuggerd/handler.h
@@ -85,6 +148,18 @@ index 7196e0ad4..9ba20db19 100644
 +#ifdef __cplusplus
 +}
 +#endif
+diff --git a/debuggerd/util.h b/debuggerd/util.h
+index e96442360..43d430314 100644
+--- a/debuggerd/util.h
++++ b/debuggerd/util.h
+@@ -18,7 +18,6 @@
+ 
+ #include <string>
+ 
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ 
+ std::string get_process_name(pid_t pid);
 diff --git a/deprecated-adf/libadf/include/adf/adf.h b/deprecated-adf/libadf/include/adf/adf.h
 index e4c7b28cc..41b3da475 100644
 --- a/deprecated-adf/libadf/include/adf/adf.h
@@ -151,6 +226,54 @@ index 4f7092507..97beb2f71 100644
 +#endif
  
  #endif /* _LIBADFHWC_ADFHWC_H_ */
+diff --git a/fs_mgr/fs_mgr_priv_boot_config.h b/fs_mgr/fs_mgr_priv_boot_config.h
+index 417fb380b..6528248a9 100644
+--- a/fs_mgr/fs_mgr_priv_boot_config.h
++++ b/fs_mgr/fs_mgr_priv_boot_config.h
+@@ -17,7 +17,6 @@
+ #ifndef __CORE_FS_MGR_PRIV_BOOTCONFIG_H
+ #define __CORE_FS_MGR_PRIV_BOOTCONFIG_H
+ 
+-#include <sys/cdefs.h>
+ #include <string>
+ #include <utility>
+ #include <vector>
+diff --git a/init/keychords.cpp b/init/keychords.cpp
+index 5f2682be5..fe00a8d7b 100644
+--- a/init/keychords.cpp
++++ b/init/keychords.cpp
+@@ -19,7 +19,6 @@
+ #include <dirent.h>
+ #include <fcntl.h>
+ #include <linux/input.h>
+-#include <sys/cdefs.h>
+ #include <sys/inotify.h>
+ #include <sys/ioctl.h>
+ #include <sys/types.h>
+diff --git a/init/reboot.cpp b/init/reboot.cpp
+index d77b9757e..9d66f4a68 100644
+--- a/init/reboot.cpp
++++ b/init/reboot.cpp
+@@ -23,7 +23,6 @@
+ #include <mntent.h>
+ #include <semaphore.h>
+ #include <stdlib.h>
+-#include <sys/cdefs.h>
+ #include <sys/ioctl.h>
+ #include <sys/mount.h>
+ #include <sys/stat.h>
+diff --git a/libasyncio/include/asyncio/AsyncIO.h b/libasyncio/include/asyncio/AsyncIO.h
+index 9620d2a84..005fc6648 100644
+--- a/libasyncio/include/asyncio/AsyncIO.h
++++ b/libasyncio/include/asyncio/AsyncIO.h
+@@ -20,7 +20,6 @@
+ #include <linux/aio_abi.h>
+ #include <stdbool.h>
+ #include <stdint.h>
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ #include <time.h>
+ #include <unistd.h>
 diff --git a/libbacktrace/backtrace_testlib.h b/libbacktrace/backtrace_testlib.h
 index 9b55e56d4..6289c66b9 100644
 --- a/libbacktrace/backtrace_testlib.h
@@ -305,6 +428,18 @@ index 8bc9b48b3..ff1d13a06 100644
 +#endif
  
  #endif /* __CUTILS_PARTITION_WIPED_H__ */
+diff --git a/libcutils/include/cutils/properties.h b/libcutils/include/cutils/properties.h
+index d2e08712a..7e0eb2ac0 100644
+--- a/libcutils/include/cutils/properties.h
++++ b/libcutils/include/cutils/properties.h
+@@ -17,7 +17,6 @@
+ #ifndef __CUTILS_PROPERTIES_H
+ #define __CUTILS_PROPERTIES_H
+ 
+-#include <sys/cdefs.h>
+ #include <stddef.h>
+ #include <sys/system_properties.h>
+ #include <stdint.h>
 diff --git a/libcutils/include/cutils/str_parms.h b/libcutils/include/cutils/str_parms.h
 index aa1435a08..160792a37 100644
 --- a/libcutils/include/cutils/str_parms.h
@@ -589,6 +724,18 @@ index 8cae66c88..c5fbc1184 100644
 +#ifdef __cplusplus
 +}
 +#endif
+diff --git a/libmemunreachable/Allocator.cpp b/libmemunreachable/Allocator.cpp
+index 1eb7e98c5..4863907d4 100644
+--- a/libmemunreachable/Allocator.cpp
++++ b/libmemunreachable/Allocator.cpp
+@@ -22,7 +22,6 @@
+ #include <assert.h>
+ #include <stdlib.h>
+ 
+-#include <sys/cdefs.h>
+ #include <sys/mman.h>
+ #include <sys/prctl.h>
+ 
 diff --git a/libmemunreachable/Binder.cpp b/libmemunreachable/Binder.cpp
 index 60512a3f8..834507459 100644
 --- a/libmemunreachable/Binder.cpp
@@ -732,6 +879,54 @@ index e89cb5400..86b6604ca 100644
 +#ifdef __cplusplus
 +}
 +#endif
+diff --git a/libpixelflinger/codeflinger/disassem.c b/libpixelflinger/codeflinger/disassem.c
+index 5cbd63db8..294b13800 100644
+--- a/libpixelflinger/codeflinger/disassem.c
++++ b/libpixelflinger/codeflinger/disassem.c
+@@ -47,7 +47,6 @@
+  * This code is not complete. Not all instructions are disassembled.
+  */
+ 
+-#include <sys/cdefs.h>
+ //__FBSDID("$FreeBSD: /repoman/r/ncvs/src/sys/arm/arm/disassem.c,v 1.2 2005/01/05 21:58:47 imp Exp $");
+ #include <sys/param.h>
+ #include <stdio.h>
+diff --git a/libpixelflinger/codeflinger/mips64_disassem.c b/libpixelflinger/codeflinger/mips64_disassem.c
+index 852829984..2f1272d6b 100644
+--- a/libpixelflinger/codeflinger/mips64_disassem.c
++++ b/libpixelflinger/codeflinger/mips64_disassem.c
+@@ -38,7 +38,6 @@
+ #include <stdbool.h>
+ #include <stdint.h>
+ #include <stdio.h>
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ 
+ #include <android/log.h>
+diff --git a/libpixelflinger/codeflinger/mips_disassem.c b/libpixelflinger/codeflinger/mips_disassem.c
+index 1fe680675..200c4abaa 100644
+--- a/libpixelflinger/codeflinger/mips_disassem.c
++++ b/libpixelflinger/codeflinger/mips_disassem.c
+@@ -38,7 +38,6 @@
+ #include <stdint.h>
+ #include <stdarg.h>
+ #include <stdbool.h>
+-#include <sys/cdefs.h>
+ 
+ #include <sys/types.h>
+ #include "mips_opcode.h"
+diff --git a/libprocessgroup/cgroup_map.h b/libprocessgroup/cgroup_map.h
+index 427d71b40..62984037d 100644
+--- a/libprocessgroup/cgroup_map.h
++++ b/libprocessgroup/cgroup_map.h
+@@ -16,7 +16,6 @@
+ 
+ #pragma once
+ 
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ 
+ #include <map>
 diff --git a/libprocessgroup/cgrouprc/include/android/cgrouprc.h b/libprocessgroup/cgrouprc/include/android/cgrouprc.h
 index 0f6a9cd5d..3a41a550d 100644
 --- a/libprocessgroup/cgrouprc/include/android/cgrouprc.h
@@ -785,6 +980,18 @@ index f73ec2d41..8f1455acf 100644
 +#ifdef __cplusplus
 +}
 +#endif
+diff --git a/libprocessgroup/task_profiles.h b/libprocessgroup/task_profiles.h
+index 9f2308c64..25c4220b3 100644
+--- a/libprocessgroup/task_profiles.h
++++ b/libprocessgroup/task_profiles.h
+@@ -16,7 +16,6 @@
+ 
+ #pragma once
+ 
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ #include <map>
+ #include <mutex>
 diff --git a/libsuspend/autosuspend_ops.h b/libsuspend/autosuspend_ops.h
 index b0024c8bb..ea0eafd00 100644
 --- a/libsuspend/autosuspend_ops.h
@@ -940,6 +1147,18 @@ index 2ca90c395..c42f55966 100644
 +#endif
  
  #endif /* SYSTEM_CORE_INCLUDE_ANDROID_CAMERA_H */
+diff --git a/libsystem/include/system/radio.h b/libsystem/include/system/radio.h
+index acf3ea787..dfd254fc6 100644
+--- a/libsystem/include/system/radio.h
++++ b/libsystem/include/system/radio.h
+@@ -20,7 +20,6 @@
+ #include <stdbool.h>
+ #include <stdint.h>
+ #include <stdio.h>
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ 
+ 
 diff --git a/libutils/Singleton_test.h b/libutils/Singleton_test.h
 index c77d9ffe6..00bd56242 100644
 --- a/libutils/Singleton_test.h
@@ -972,6 +1191,18 @@ index c77d9ffe6..00bd56242 100644
  
  }
  
+diff --git a/libziparchive/include/ziparchive/zip_archive.h b/libziparchive/include/ziparchive/zip_archive.h
+index e3ac114f2..30518f0fe 100644
+--- a/libziparchive/include/ziparchive/zip_archive.h
++++ b/libziparchive/include/ziparchive/zip_archive.h
+@@ -22,7 +22,6 @@
+ 
+ #include <stdint.h>
+ #include <string.h>
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ 
+ #include <string>
 diff --git a/llkd/include/llkd.h b/llkd/include/llkd.h
 index 3586ca1b1..b606c60d8 100644
 --- a/llkd/include/llkd.h
@@ -1019,6 +1250,18 @@ index 3586ca1b1..b606c60d8 100644
  std::chrono::milliseconds llkCheck(bool checkRunning = false);
  
  /* clang-format off */
+diff --git a/llkd/libllkd.cpp b/llkd/libllkd.cpp
+index b26ad4df6..95cc6d04d 100644
+--- a/llkd/libllkd.cpp
++++ b/llkd/libllkd.cpp
+@@ -25,7 +25,6 @@
+ #include <signal.h>
+ #include <stdint.h>
+ #include <string.h>
+-#include <sys/cdefs.h>  // ___STRING, __predict_true() and _predict_false()
+ #include <sys/mman.h>   // mlockall()
+ #include <sys/prctl.h>
+ #include <sys/stat.h>     // lstat()
 diff --git a/lmkd/include/liblmkd_utils.h b/lmkd/include/liblmkd_utils.h
 index 72e3f4a2b..64d060c6a 100644
 --- a/lmkd/include/liblmkd_utils.h
@@ -1077,6 +1320,18 @@ index 59377dd1f..bdc5413f2 100644
 +#endif
  
  #endif /* _LMKD_H_ */
+diff --git a/lmkd/liblmkd_utils.c b/lmkd/liblmkd_utils.c
+index fa3b7a920..3f76a35dd 100644
+--- a/lmkd/liblmkd_utils.c
++++ b/lmkd/liblmkd_utils.c
+@@ -16,7 +16,6 @@
+ 
+ #include <errno.h>
+ #include <fcntl.h>
+-#include <sys/cdefs.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <stdio.h>
 diff --git a/lmkd/libpsi/include/psi/psi.h b/lmkd/libpsi/include/psi/psi.h
 index cd49e8b60..b4f4afe70 100644
 --- a/lmkd/libpsi/include/psi/psi.h
@@ -1105,6 +1360,18 @@ index cd49e8b60..b4f4afe70 100644
 +#endif
  
  #endif  // __ANDROID_PSI_H__
+diff --git a/lmkd/lmkd.c b/lmkd/lmkd.c
+index 9de7ff7b7..8d96149f6 100644
+--- a/lmkd/lmkd.c
++++ b/lmkd/lmkd.c
+@@ -25,7 +25,6 @@
+ #include <stdbool.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <sys/cdefs.h>
+ #include <sys/epoll.h>
+ #include <sys/eventfd.h>
+ #include <sys/mman.h>
 diff --git a/lmkd/statslog.h b/lmkd/statslog.h
 index a09c7dd91..1c10f609b 100644
 --- a/lmkd/statslog.h
@@ -1134,6 +1401,66 @@ index a09c7dd91..1c10f609b 100644
 +#endif
  
  #endif /* _STATSLOG_H_ */
+diff --git a/logcat/logcat.cpp b/logcat/logcat.cpp
+index 4dcb3383e..5b261dc79 100644
+--- a/logcat/logcat.cpp
++++ b/logcat/logcat.cpp
+@@ -31,7 +31,6 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <sys/cdefs.h>
+ #include <sys/ioctl.h>
+ #include <sys/resource.h>
+ #include <sys/socket.h>
+diff --git a/logcat/tests/logcat_test.cpp b/logcat/tests/logcat_test.cpp
+index b32b43737..a9f0a7738 100644
+--- a/logcat/tests/logcat_test.cpp
++++ b/logcat/tests/logcat_test.cpp
+@@ -21,7 +21,6 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <sys/cdefs.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
+diff --git a/logd/LogBuffer.cpp b/logd/LogBuffer.cpp
+index ba05a064f..f244dec30 100644
+--- a/logd/LogBuffer.cpp
++++ b/logd/LogBuffer.cpp
+@@ -21,7 +21,6 @@
+ #include <errno.h>
+ #include <stdio.h>
+ #include <string.h>
+-#include <sys/cdefs.h>
+ #include <sys/user.h>
+ #include <time.h>
+ #include <unistd.h>
+diff --git a/logd/LogListener.cpp b/logd/LogListener.cpp
+index 443570fd3..493756c60 100644
+--- a/logd/LogListener.cpp
++++ b/logd/LogListener.cpp
+@@ -15,7 +15,6 @@
+  */
+ 
+ #include <limits.h>
+-#include <sys/cdefs.h>
+ #include <sys/prctl.h>
+ #include <sys/socket.h>
+ #include <sys/types.h>
+diff --git a/logd/LogUtils.h b/logd/LogUtils.h
+index fa9f39895..67d448e4e 100644
+--- a/logd/LogUtils.h
++++ b/logd/LogUtils.h
+@@ -17,7 +17,6 @@
+ #ifndef _LOGD_LOG_UTILS_H__
+ #define _LOGD_LOG_UTILS_H__
+ 
+-#include <sys/cdefs.h>
+ #include <sys/types.h>
+ 
+ #include <private/android_logger.h>
 diff --git a/logd/libaudit.h b/logd/libaudit.h
 index b4a92a8a3..6cf37914e 100644
 --- a/logd/libaudit.h
@@ -1236,3 +1563,6 @@ index b8ddf67d8..6cac8750c 100644
 +#ifdef __cplusplus
 +}
 +#endif
+-- 
+2.25.1
+

--- a/patches/core/0022-liblog-Fix-initialization-of-android_log_transport_w.patch
+++ b/patches/core/0022-liblog-Fix-initialization-of-android_log_transport_w.patch
@@ -1,0 +1,22 @@
+From 1834e64f1bb3315cbdf7b0668213919da59a9d62 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6ren=20Tempel?= <soeren+git@soeren-tempel.net>
+Date: Wed, 21 Aug 2019 20:01:26 +0200
+Subject: [PATCH] liblog: Fix initialization of android_log_transport_write
+
+---
+ liblog/fake_writer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/liblog/fake_writer.cpp b/liblog/fake_writer.cpp
+index f1ddff17b..a363731b8 100644
+--- a/liblog/fake_writer.cpp
++++ b/liblog/fake_writer.cpp
+@@ -34,7 +34,7 @@ static int logFds[(int)LOG_ID_MAX] = {-1, -1, -1, -1, -1, -1};
+ struct android_log_transport_write fakeLoggerWrite = {
+     .name = "fake",
+     .logMask = 0,
+-    .context.priv = &logFds,
++    .context = { .priv = &logFds },
+     .available = fakeAvailable,
+     .open = fakeOpen,
+     .close = fakeClose,

--- a/patches/core/0023-adb-disable-fastdeploy-support.patch
+++ b/patches/core/0023-adb-disable-fastdeploy-support.patch
@@ -1,0 +1,107 @@
+From 3960fd22b7637059b654f879a6e31e5b349fc992 Mon Sep 17 00:00:00 2001
+From: Minecrell <minecrell@minecrell.net>
+Date: Thu, 27 Feb 2020 14:06:16 +0100
+Subject: [PATCH] adb: disable fastdeploy support
+
+The "fastdeploy" support in ADB seems extremely complicated, it requires
+additional dependencies on protobuf and Java,
+see: https://git.archlinux.org/svntogit/community.git/commit/trunk/PKGBUILD?h=packages/android-tools&id=18cab8db85b81471e3beb90a0543945fb31f84bb
+
+For now lets just disable it (like it was on platform-tools-29.0.4).
+If someone wants to make it work, feel free to :)
+---
+ adb/client/adb_install.cpp | 10 ++++++++++
+ adb/client/fastdeploy.h    |  4 ++++
+ 2 files changed, 14 insertions(+)
+
+diff --git a/adb/client/adb_install.cpp b/adb/client/adb_install.cpp
+index 73dcde1fe..5ef7a48a3 100644
+--- a/adb/client/adb_install.cpp
++++ b/adb/client/adb_install.cpp
+@@ -167,6 +167,7 @@ static int install_app_streamed(int argc, const char** argv, bool use_fastdeploy
+     }
+ 
+     if (use_fastdeploy) {
++#if defined(ENABLE_FASTDEPLOY)
+         auto metadata = extract_metadata(file);
+         if (metadata.has_value()) {
+             // pass all but 1st (command) and last (apk path) parameters through to pm for
+@@ -175,6 +176,9 @@ static int install_app_streamed(int argc, const char** argv, bool use_fastdeploy
+             auto patchFd = install_patch(pm_args.size(), pm_args.data());
+             return stream_patch(file, std::move(metadata.value()), std::move(patchFd));
+         }
++#else
++        error_exit("fastdeploy is disabled");
++#endif
+     }
+ 
+     struct stat sb;
+@@ -263,6 +267,7 @@ static int install_app_legacy(int argc, const char** argv, bool use_fastdeploy)
+     argv[last_apk] = apk_dest.c_str(); /* destination name, not source location */
+ 
+     if (use_fastdeploy) {
++#if defined(ENABLE_FASTDEPLOY)
+         auto metadata = extract_metadata(apk_file[0]);
+         if (metadata.has_value()) {
+             auto patchFd = apply_patch_on_device(apk_dest.c_str());
+@@ -273,6 +278,9 @@ static int install_app_legacy(int argc, const char** argv, bool use_fastdeploy)
+ 
+             return status;
+         }
++#else
++        error_exit("fastdeploy is disabled");
++#endif
+     }
+ 
+     if (do_sync_push(apk_file, apk_dest.c_str(), false)) {
+@@ -327,6 +335,7 @@ int install_app(int argc, const char** argv) {
+         error_exit("Attempting to use streaming install on unsupported device");
+     }
+ 
++#if defined(ENABLE_FASTDEPLOY)
+     if (use_fastdeploy && get_device_api_level() < kFastDeployMinApi) {
+         printf("Fast Deploy is only compatible with devices of API version %d or higher, "
+                "ignoring.\n",
+@@ -334,6 +343,7 @@ int install_app(int argc, const char** argv) {
+         use_fastdeploy = false;
+     }
+     fastdeploy_set_agent_update_strategy(agent_update_strategy);
++#endif
+ 
+     std::vector<const char*> passthrough_argv;
+     for (int i = 0; i < argc; i++) {
+diff --git a/adb/client/fastdeploy.h b/adb/client/fastdeploy.h
+index 830aeb2ca..25f3f9efe 100644
+--- a/adb/client/fastdeploy.h
++++ b/adb/client/fastdeploy.h
+@@ -16,12 +16,14 @@
+ 
+ #pragma once
+ 
++#if defined(ENABLE_FASTDEPLOY)
+ #include "adb_unique_fd.h"
+ 
+ #include "fastdeploy/proto/ApkEntry.pb.h"
+ 
+ #include <optional>
+ #include <string>
++#endif
+ 
+ enum FastDeploy_AgentUpdateStrategy {
+     FastDeploy_AgentUpdateAlways,
+@@ -29,6 +31,7 @@ enum FastDeploy_AgentUpdateStrategy {
+     FastDeploy_AgentUpdateDifferentVersion
+ };
+ 
++#if defined(ENABLE_FASTDEPLOY)
+ void fastdeploy_set_agent_update_strategy(FastDeploy_AgentUpdateStrategy agent_update_strategy);
+ int get_device_api_level();
+ 
+@@ -37,3 +40,4 @@ unique_fd install_patch(int argc, const char** argv);
+ unique_fd apply_patch_on_device(const char* output_path);
+ int stream_patch(const char* apk_path, com::android::fastdeploy::APKMetaData metadata,
+                  unique_fd patch_fd);
++#endif
+-- 
+2.25.1
+

--- a/patches/core/0024-android-base-endian.h-fix-build-on-musl.patch
+++ b/patches/core/0024-android-base-endian.h-fix-build-on-musl.patch
@@ -1,0 +1,37 @@
+From e7f6f2a9af0c53a1e5e512e63268a0aac6f3a35b Mon Sep 17 00:00:00 2001
+From: Minecrell <minecrell@minecrell.net>
+Date: Sat, 29 Feb 2020 13:22:44 +0100
+Subject: [PATCH] android-base/endian.h: fix build on musl
+
+So far musl has used the definitions for Windows. Now that it includes
+<winsock2.h> this fails horribly. Add a proper fallback for !__GLIBC__
+but __linux__ with defines for musl.
+---
+ base/include/android-base/endian.h | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/base/include/android-base/endian.h b/base/include/android-base/endian.h
+index 1e5cceb9a..c85c0ae30 100644
+--- a/base/include/android-base/endian.h
++++ b/base/include/android-base/endian.h
+@@ -44,6 +44,17 @@
+ #define letoh32(x) le32toh(x)
+ #define letoh64(x) le64toh(x)
+ 
++#elif defined(__linux__)
++/* musl's <endian.h> is like bionic's <sys/endian.h>. */
++#include <endian.h>
++
++/* musl keeps htons and htonl in <netinet/in.h>. */
++#include <netinet/in.h>
++
++/* musl doesn't have the 64-bit variants. */
++#define htonq(x) htobe64(x)
++#define ntohq(x) be64toh(x)
++
+ #else
+ 
+ #if defined(__APPLE__)
+-- 
+2.25.1
+

--- a/vendor/CMakeLists.adb.txt
+++ b/vendor/CMakeLists.adb.txt
@@ -1,21 +1,20 @@
 add_library(libadb STATIC
-	core/adb/socket_spec.cpp
-	core/adb/services.cpp
-	core/adb/sysdeps_unix.cpp
-	core/adb/sysdeps/errno.cpp
-	core/adb/sysdeps/posix/network.cpp
-	core/adb/client/main.cpp
-	core/adb/client/auth.cpp
-	core/adb/client/commandline.cpp
 	core/adb/client/adb_client.cpp
-	core/adb/client/usb_dispatch.cpp
-	core/adb/client/usb_linux.cpp
-	core/adb/client/usb_libusb.cpp
+	core/adb/client/adb_install.cpp
+	core/adb/client/auth.cpp
 	core/adb/client/bugreport.cpp
+	core/adb/client/commandline.cpp
+	core/adb/client/console.cpp
 	core/adb/client/file_sync_client.cpp
 	core/adb/client/line_printer.cpp
-	core/adb/client/adb_install.cpp
-	core/adb/client/console.cpp
+	core/adb/client/main.cpp
+	core/adb/client/usb_dispatch.cpp
+	core/adb/client/usb_libusb.cpp
+	core/adb/client/usb_linux.cpp
+	core/adb/services.cpp
+	core/adb/socket_spec.cpp
+	core/adb/sysdeps_unix.cpp
+	core/adb/sysdeps/errno.cpp
 	core/adb/sysdeps/posix/network.cpp)
 
 target_compile_definitions(libadb PRIVATE -D_GNU_SOURCE)
@@ -24,31 +23,28 @@ target_include_directories(libadb PUBLIC
 	core/include core/base/include core/adb boringssl/include core/libcrypto_utils/include)
 
 add_library(libbase STATIC
+	core/base/chrono_utils.cpp
+	core/base/errors_unix.cpp
 	core/base/file.cpp
 	core/base/logging.cpp
+	core/base/mapped_file.cpp
 	core/base/parsenetaddress.cpp
 	core/base/stringprintf.cpp
 	core/base/strings.cpp
-	core/base/errors_unix.cpp
 	core/base/test_utils.cpp
-	core/base/mapped_file.cpp
-	core/base/chrono_utils.cpp
 	core/base/threads.cpp)
 
 target_include_directories(libbase PUBLIC
 	core/base/include core/include)
 
 add_library(liblog STATIC
-	core/liblog/log_event_write.cpp
 	core/liblog/fake_log_device.cpp
-	core/liblog/log_event_list.cpp
-	core/liblog/logger_write.cpp
-	core/liblog/config_write.cpp
-	core/liblog/config_read.cpp
-	core/liblog/logger_lock.cpp
 	core/liblog/fake_writer.cpp
+	core/liblog/log_event_list.cpp
+	core/liblog/log_event_write.cpp
+	core/liblog/logger_lock.cpp
 	core/liblog/logger_name.cpp
-	core/liblog/stderr_write.cpp
+	core/liblog/logger_write.cpp
 	core/liblog/logprint.cpp)
 
 target_compile_definitions(liblog PRIVATE
@@ -57,17 +53,17 @@ target_include_directories(liblog PUBLIC
 	core/log/include core/include)
 
 add_library(libcutils STATIC
-	core/libcutils/load_file.cpp
-	core/libcutils/socket_local_client_unix.cpp
-	core/libcutils/socket_network_client_unix.cpp
-	core/libcutils/socket_local_server_unix.cpp
-	core/libcutils/sockets_unix.cpp
-	core/libcutils/socket_inaddr_any_server_unix.cpp
-	core/libcutils/sockets.cpp
 	core/libcutils/android_get_control_file.cpp
-	core/libcutils/threads.cpp
+	core/libcutils/canned_fs_config.cpp
 	core/libcutils/fs_config.cpp
-	core/libcutils/canned_fs_config.cpp)
+	core/libcutils/load_file.cpp
+	core/libcutils/socket_inaddr_any_server_unix.cpp
+	core/libcutils/socket_local_client_unix.cpp
+	core/libcutils/socket_local_server_unix.cpp
+	core/libcutils/socket_network_client_unix.cpp
+	core/libcutils/sockets_unix.cpp
+	core/libcutils/sockets.cpp
+	core/libcutils/threads.cpp)
 
 target_compile_definitions(libcutils PRIVATE -D_GNU_SOURCE)
 target_include_directories(libcutils PRIVATE
@@ -95,13 +91,14 @@ add_executable(adb
 	  core/adb/adb_listeners.cpp
 	  core/adb/adb_trace.cpp
 	  core/adb/adb_utils.cpp
+	  core/adb/fdevent/fdevent.cpp
+	  core/adb/fdevent/fdevent_poll.cpp
+	  core/adb/fdevent/fdevent_epoll.cpp
+	  core/adb/shell_service_protocol.cpp
 	  core/adb/sockets.cpp
 	  core/adb/transport.cpp
 	  core/adb/transport_local.cpp
-	  core/adb/transport_usb.cpp
-	  core/adb/fdevent/fdevent.cpp
-	  core/adb/fdevent/fdevent_poll.cpp
-	  core/adb/shell_service_protocol.cpp)
+	  core/adb/transport_usb.cpp)
 
 target_compile_definitions(adb PRIVATE
 	-DPLATFORM_TOOLS_VERSION="${ANDROID_VERSION}"

--- a/vendor/CMakeLists.fastboot.txt
+++ b/vendor/CMakeLists.fastboot.txt
@@ -5,10 +5,15 @@ target_include_directories(libzip PUBLIC
 	core/base/include core/include core/libziparchive/include)
 
 add_library(libutil STATIC
-	core/libutils/FileMap.cpp)
+	core/libutils/FileMap.cpp
+	core/libutils/SharedBuffer.cpp
+	core/libutils/String16.cpp
+	core/libutils/String8.cpp
+	core/libutils/VectorImpl.cpp
+	core/libutils/Unicode.cpp)
 
 target_include_directories(libutil PUBLIC
-	core/include)
+	core/include core/base/include)
 
 add_library(libext4 STATIC
 	extras/ext4_utils/ext4_utils.cpp
@@ -20,41 +25,41 @@ target_include_directories(libext4 PUBLIC
 	extras/ext4_utils/include core/base/include)
 
 add_library(libfsmgr STATIC
-	core/fs_mgr/liblp/reader.cpp
-	core/fs_mgr/liblp/writer.cpp
-	core/fs_mgr/liblp/utility.cpp
+	core/fs_mgr/liblp/images.cpp
 	core/fs_mgr/liblp/partition_opener.cpp
-	core/fs_mgr/liblp/images.cpp)
+	core/fs_mgr/liblp/reader.cpp
+	core/fs_mgr/liblp/utility.cpp
+	core/fs_mgr/liblp/writer.cpp)
 target_include_directories(libfsmgr PRIVATE
 	core/fs_mgr/liblp/include core/base/include
 	extras/ext4_utils/include core/libsparse/include
 	boringssl/include)
 
 add_library(libselinux STATIC
+	selinux/libselinux/src/booleans.c
 	selinux/libselinux/src/callbacks.c
+	selinux/libselinux/src/canonicalize_context.c
 	selinux/libselinux/src/check_context.c
+	selinux/libselinux/src/disable.c
+	selinux/libselinux/src/enabled.c
 	selinux/libselinux/src/freecon.c
+	selinux/libselinux/src/getenforce.c
 	selinux/libselinux/src/init.c
+	selinux/libselinux/src/label_backends_android.c
 	selinux/libselinux/src/label.c
 	selinux/libselinux/src/label_file.c
 	selinux/libselinux/src/label_support.c
-	selinux/libselinux/src/setrans_client.c
-	selinux/libselinux/src/regex.c
-	selinux/libselinux/src/matchpathcon.c
-	selinux/libselinux/src/selinux_config.c
-	selinux/libselinux/src/label_backends_android.c
-	selinux/libselinux/src/canonicalize_context.c
-	selinux/libselinux/src/lsetfilecon.c
-	selinux/libselinux/src/policyvers.c
 	selinux/libselinux/src/lgetfilecon.c
 	selinux/libselinux/src/load_policy.c
+	selinux/libselinux/src/lsetfilecon.c
+	selinux/libselinux/src/matchpathcon.c
+	selinux/libselinux/src/policyvers.c
+	selinux/libselinux/src/regex.c
+	selinux/libselinux/src/selinux_config.c
+	selinux/libselinux/src/setenforce.c
+	selinux/libselinux/src/setrans_client.c
 	selinux/libselinux/src/seusers.c
-	selinux/libselinux/src/sha1.c
-	selinux/libselinux/src/booleans.c
-	selinux/libselinux/src/disable.c
-	selinux/libselinux/src/enabled.c
-	selinux/libselinux/src/getenforce.c
-	selinux/libselinux/src/setenforce.c)
+	selinux/libselinux/src/sha1.c)
 
 target_compile_definitions(libselinux PRIVATE
 	-DAUDITD_LOG_TAG=1003 -D_GNU_SOURCE -DHOST -DUSE_PCRE2
@@ -65,50 +70,51 @@ target_include_directories(libselinux PUBLIC
 	selinux/libselinux/include selinux/libsepol/include)
 
 add_library(libsepol
-	selinux/libsepol/src/policydb_public.c
-	selinux/libsepol/src/genbools.c
-	selinux/libsepol/src/debug.c
-	selinux/libsepol/src/policydb.c
-	selinux/libsepol/src/conditional.c
-	selinux/libsepol/src/services.c
-	selinux/libsepol/src/ebitmap.c
-	selinux/libsepol/src/util.c
 	selinux/libsepol/src/assertion.c
-	selinux/libsepol/src/avtab.c
-	selinux/libsepol/src/hashtab.c
-	selinux/libsepol/src/sidtab.c
-	selinux/libsepol/src/context.c
-	selinux/libsepol/src/genusers.c
-	selinux/libsepol/src/context_record.c
-	selinux/libsepol/src/mls.c
 	selinux/libsepol/src/avrule_block.c
-	selinux/libsepol/src/symtab.c
-	selinux/libsepol/src/policydb_convert.c
-	selinux/libsepol/src/write.c
+	selinux/libsepol/src/avtab.c
+	selinux/libsepol/src/conditional.c
 	selinux/libsepol/src/constraint.c
+	selinux/libsepol/src/context.c
+	selinux/libsepol/src/context_record.c
+	selinux/libsepol/src/debug.c
+	selinux/libsepol/src/ebitmap.c
 	selinux/libsepol/src/expand.c
-	selinux/libsepol/src/hierarchy.c)
+	selinux/libsepol/src/genbools.c
+	selinux/libsepol/src/genusers.c
+	selinux/libsepol/src/hashtab.c
+	selinux/libsepol/src/hierarchy.c
+	selinux/libsepol/src/kernel_to_common.c
+	selinux/libsepol/src/mls.c
+	selinux/libsepol/src/policydb.c
+	selinux/libsepol/src/policydb_convert.c
+	selinux/libsepol/src/policydb_public.c
+	selinux/libsepol/src/services.c
+	selinux/libsepol/src/sidtab.c
+	selinux/libsepol/src/symtab.c
+	selinux/libsepol/src/util.c
+	selinux/libsepol/src/write.c)
 
 target_include_directories(libsepol PUBLIC
 	selinux/libsepol/include)
 
 add_executable(fastboot
-	core/fastboot/fastboot_driver.cpp
 	core/fastboot/bootimg_utils.cpp
 	core/fastboot/fastboot.cpp
-	core/fastboot/main.cpp
-	core/fastboot/util.cpp
+	core/fastboot/fastboot_driver.cpp
 	core/fastboot/fs.cpp
-	core/fastboot/usb_linux.cpp
+	core/fastboot/main.cpp
 	core/fastboot/socket.cpp
 	core/fastboot/tcp.cpp
-	core/fastboot/udp.cpp)
+	core/fastboot/udp.cpp
+	core/fastboot/usb_linux.cpp
+	core/fastboot/util.cpp)
 
 target_include_directories(fastboot PRIVATE
 	core/base/include core/include core/adb core/libsparse/include
 	extras/ext4_utils/include extras/f2fs_utils
 	core/libziparchive/include mkbootimg/include/bootimg
-	core/fs_mgr/liblp/include)
+	core/fs_mgr/liblp/include avb)
 target_compile_definitions(fastboot PRIVATE
 	-DPLATFORM_TOOLS_VERSION="${ANDROID_VERSION}"
 	-DPLATFORM_TOOLS_VENDOR="${ANDROID_VENDOR}"

--- a/vendor/CMakeLists.mke2fs.txt
+++ b/vendor/CMakeLists.mke2fs.txt
@@ -10,6 +10,7 @@ add_library(libext2fs STATIC
 	e2fsprogs/lib/blkid/resolve.c
 	e2fsprogs/lib/blkid/save.c
 	e2fsprogs/lib/blkid/tag.c
+	e2fsprogs/lib/e2p/encoding.c
 	e2fsprogs/lib/e2p/feature.c
 	e2fsprogs/lib/e2p/hashstr.c
 	e2fsprogs/lib/e2p/mntopts.c
@@ -68,6 +69,7 @@ add_library(libext2fs STATIC
 	e2fsprogs/lib/ext2fs/mmp.c
 	e2fsprogs/lib/ext2fs/namei.c
 	e2fsprogs/lib/ext2fs/newdir.c
+	e2fsprogs/lib/ext2fs/nls_utf8.c
 	e2fsprogs/lib/ext2fs/openfs.c
 	e2fsprogs/lib/ext2fs/progress.c
 	e2fsprogs/lib/ext2fs/punch.c


### PR DESCRIPTION
I set the target to your `platform-tools-29.0.5` branch so you can see the changes I made:

- Fix some more sys/cdefs.h includes
- Restore liblog patch that is still needed for GCC
- Disable ADB fastdeploy support to avoid Java/protobuf dependency mess
- Update source files in CMakeLists
- Add avb submodule which is needed for fastboot now
- Add endian.h patch for musl to avoid using Windows defines

If someone would like to go through the mess required to make fastdeploy work (requires a lot more Android sources to build the Java part, plus protobuf) they are free to do so. (See e.g. https://git.archlinux.org/svntogit/community.git/commit/trunk?h=packages/android-tools&id=18cab8db85b81471e3beb90a0543945fb31f84bb).  
For now I have added a patch to disable it (as it was on previous releases...)

Builds fine on glibc and musl (for me). Tested `adb` and `fastboot` a bit. Crashes on Alpine are fixed (some weird assertions) and seems to work fine overall.