### PR TITLE
vendor: CMakeLists: fix dependencies on protobuf header

### DIFF
--- a/vendor/CMakeLists.adb.txt
+++ b/vendor/CMakeLists.adb.txt
@@ -34,19 +34,10 @@ add_library(libadb STATIC
 	core/adb/sysdeps_unix.cpp
 	core/adb/sysdeps/errno.cpp
 	core/adb/sysdeps/posix/network.cpp
-	${ADB_APP_PROCESSES_PROTO_SRCS}
-	${ADB_KNOWN_HOSTS_PROTO_SRCS}
-	${ADB_KEY_TYPE_PROTO_SRCS}
-	${ADB_PAIRING_PROTO_SRCS})
-
-set_property(SOURCE core/adb/client/commandline.cpp
-	PROPERTY OBJECT_DEPENDS ${ADB_APP_PROCESSES_PROTO_HDRS})
-set_property(SOURCE core/adb/client/adb_wifi.cpp
-	PROPERTY OBJECT_DEPENDS ${ADB_KNOWN_HOSTS_PROTO_HDRS})
-set_property(SOURCE core/adb/client/auth.cpp
-	PROPERTY OBJECT_DEPENDS ${ADB_KEY_TYPE_PROTO_HDRS})
-set_property(SOURCE core/adb/pairing_connection/pairing_connection.cpp
-	PROPERTY OBJECT_DEPENDS ${ADB_PAIRING_PROTO_HDRS})
+	${ADB_APP_PROCESSES_PROTO_SRCS} ${ADB_APP_PROCESSES_PROTO_HDRS}
+	${ADB_KNOWN_HOSTS_PROTO_SRCS} ${ADB_KNOWN_HOSTS_PROTO_HDRS}
+	${ADB_KEY_TYPE_PROTO_SRCS} ${ADB_KEY_TYPE_PROTO_HDRS}
+	${ADB_PAIRING_PROTO_SRCS} ${ADB_PAIRING_PROTO_HDRS})
 
 target_compile_definitions(libadb PRIVATE -D_GNU_SOURCE)
 target_compile_definitions(libadb PUBLIC -DADB_HOST=1)
@@ -68,7 +59,8 @@ target_include_directories(libadb PUBLIC
 add_library(libadb_crypto_defaults STATIC
 	core/adb/crypto/key.cpp
 	core/adb/crypto/rsa_2048_key.cpp
-	core/adb/crypto/x509_generator.cpp)
+	core/adb/crypto/x509_generator.cpp
+	${ADB_KEY_TYPE_PROTO_HDRS})
 
 target_include_directories(libadb_crypto_defaults PUBLIC
 	core/adb
@@ -173,7 +165,8 @@ add_executable(adb
 	  core/adb/transport_fd.cpp
 	  core/adb/client/transport_local.cpp
 	  core/adb/client/transport_usb.cpp
-	  core/adb/types.cpp)
+	  core/adb/types.cpp
+	  ${ADB_KEY_TYPE_PROTO_HDRS})
 
 target_compile_definitions(adb PRIVATE
 	-DPLATFORM_TOOLS_VERSION="${ANDROID_VERSION}"


### PR DESCRIPTION
While we're at it, simplify OBJECT_DEPENDS as pointed out in
https://cmake.org/cmake/help/v3.18/prop_sf/OBJECT_DEPENDS.html

This fix a broken build because of a race as shown in:
https://github.com/void-linux/void-packages/pull/28209/checks?check_run_id=1758983334