### PR TITLE
Remove _adb from zsh completions

### DIFF
--- a/completions/zsh/CMakeLists.txt
+++ b/completions/zsh/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(ZSH_COMPLETION_DIR "${CMAKE_INSTALL_FULL_DATADIR}/zsh/site-functions")
 
-configure_file(adb.in _adb)
 configure_file(fastboot.in _fastboot)
+# _adb completion is provided by zsh itself
 
 install(FILES
-	"${CMAKE_CURRENT_BINARY_DIR}/_adb"
 	"${CMAKE_CURRENT_BINARY_DIR}/_fastboot"
 	DESTINATION "${ZSH_COMPLETION_DIR}")

--- a/completions/zsh/adb.in
+++ b/completions/zsh/adb.in
@@ -1,8 +1,0 @@
-# Bash completions for adb.
-# See https://github.com/nmeum/android-tools/issues/22
-
-function check_type() {
-	type "$1"
-}
-
-source "@COMPLETION_COMMON_DIR@/adb"


### PR DESCRIPTION
Upstream zsh already provides completion for `_adb` and it seems work better than the AOSP one.

Closes #38 