### PR TITLE
GitHub ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,106 @@
+
+name: build
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  #push:
+  #  branches: [ master ]
+  #pull_request:
+  #  branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # for single tests (comment all the other defs)
+        #os: ["opensuse/leap:15.3"]
+        #pkgs: ["clang gcc10 gcc10-c++"]
+        #vars1: ["CC=clang CXX=clang++"]
+        os: ["opensuse/leap:15.3"]
+        pkgs: ["gcc10 gcc10-c++"]
+        vars1: ["CC=gcc-10 CXX=g++-10"]
+        include:
+          - os: "opensuse/leap:15.3"
+            pkgs: "clang gcc10 gcc10-c++"
+            vars1: "CC=clang CXX=clang++"
+          - os: "opensuse/tumbleweed"
+            pkgs: "gcc gcc-c++"
+            vars1: "CFLAGS='-Wno-error=array-parameter -Wno-error=array-bounds -Wno-error=stringop-overflow'"
+            vars2: "CXXFLAGS=\"$CFLAGS\""
+          - os: "opensuse/tumbleweed"
+            pkgs: clang
+            vars1: "CC=clang CXX=clang++"
+          - os: "archlinux:base"
+            pkgs: gcc
+            vars1: "CFLAGS='-Wno-error=array-parameter -Wno-error=array-bounds -Wno-error=stringop-overflow'"
+            vars2: "CXXFLAGS=\"$CFLAGS\""
+          - os: "archlinux:base"
+            pkgs: clang
+            vars1: "CC=clang CXX=clang++"
+          # build fails
+          #- os: "ubuntu:20.04"
+          #  pkgs: "gcc-10 g++-10"
+          #  vars1: "CC=gcc-10 CXX=g++-10"
+          # build fails
+          #- os: "ubuntu:20.04"
+          #  pkgs: clang
+          #  vars1: "CC=clang CXX=clang++"
+
+    container:
+      image: ${{ matrix.os }}
+
+    steps:
+      - name: prep opensuse
+        if: startsWith(matrix.os, 'opensuse')
+        run: |
+          zypper -n ref
+          zypper -n in ${{ matrix.pkgs }} cmake git go gtest pcre2-devel pkgconfig \
+            'pkgconfig(fmt)' 'pkgconfig(libbrotlicommon)' 'pkgconfig(liblz4)' \
+            'pkgconfig(libunwind-generic)' 'pkgconfig(libusb-1.0)' \
+            'pkgconfig(libzstd)' 'pkgconfig(protobuf)'
+
+      - name: prep archlinux
+        if: startsWith(matrix.os, 'archlinux')
+        run: |
+          pacman -Syu --needed --noconfirm \
+            ${{ matrix.pkgs }} brotli cmake fmt git go gtest libunwind \
+            libusb lz4 make pcre2 pkgconfig protobuf zstd
+
+      - name: prep ubuntu
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+            ${{ matrix.pkgs }} cmake git golang libbrotli-dev libfmt-dev \
+            libgtest-dev liblz4-dev libpcre2-dev libprotobuf-dev libunwind-dev \
+            libusb-1.0-0-dev libzstd-dev make pkg-config
+
+      # required for patches
+      - name: git config
+        run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: build & install
+        run: |
+          test -n "${{ matrix.vars1 }}" && export ${{ matrix.vars1 }}
+          test -n "${{ matrix.vars2 }}" && export ${{ matrix.vars2 }}
+          mkdir build && cd build
+          cmake -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON ..
+          make -O VERBOSE=1 -j
+          echo -e "\n### make install ###\n"
+          make install
+          echo -e "\n### make package_source ###\n"
+          make package_source
+          echo -e "\n### all done ###\n"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,56 +1,66 @@
-
 name: build
 
-on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  #push:
-  #  branches: [ master ]
-  #pull_request:
-  #  branches: [ master ]
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+on: [push, pull_request]
 
 jobs:
+  upload-src:
+    name: Upload the source
+    runs-on: ubuntu-latest
+    steps:
+      - name: prep ubuntu
+        run: |
+          sudo apt-get update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
+            ${{ matrix.pkgs }} cmake git golang libbrotli-dev libfmt-dev \
+            libgtest-dev liblz4-dev libpcre2-dev libprotobuf-dev libunwind-dev \
+            libusb-1.0-0-dev libzstd-dev make pkg-config
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: git config
+        run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+      - name: build & install
+        run: |
+          mkdir build && cd build
+          cmake ..
+          make package_source
+      - name: upload package_source
+        uses: actions/upload-artifact@v2
+        with:
+          name: package_source
+          path: ${{ github.workspace }}/build/android-tools-*.tar.xz
   build:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        # for single tests (comment all the other defs)
-        #os: ["opensuse/leap:15.3"]
-        #pkgs: ["clang gcc10 gcc10-c++"]
-        #vars1: ["CC=clang CXX=clang++"]
-        os: ["opensuse/leap:15.3"]
-        pkgs: ["gcc10 gcc10-c++"]
-        vars1: ["CC=gcc-10 CXX=g++-10"]
         include:
           - os: "opensuse/leap:15.3"
             pkgs: "clang gcc10 gcc10-c++"
-            vars1: "CC=clang CXX=clang++"
+            env1: "CC=clang CXX=clang++"
           - os: "opensuse/tumbleweed"
             pkgs: "gcc gcc-c++"
-            vars1: "CFLAGS='-Wno-error=array-parameter -Wno-error=array-bounds -Wno-error=stringop-overflow'"
-            vars2: "CXXFLAGS=\"$CFLAGS\""
           - os: "opensuse/tumbleweed"
             pkgs: clang
-            vars1: "CC=clang CXX=clang++"
+            env1: "CC=clang CXX=clang++"
           - os: "archlinux:base"
             pkgs: gcc
-            vars1: "CFLAGS='-Wno-error=array-parameter -Wno-error=array-bounds -Wno-error=stringop-overflow'"
-            vars2: "CXXFLAGS=\"$CFLAGS\""
           - os: "archlinux:base"
             pkgs: clang
-            vars1: "CC=clang CXX=clang++"
-          # build fails
-          #- os: "ubuntu:20.04"
-          #  pkgs: "gcc-10 g++-10"
-          #  vars1: "CC=gcc-10 CXX=g++-10"
-          # build fails
-          #- os: "ubuntu:20.04"
-          #  pkgs: clang
-          #  vars1: "CC=clang CXX=clang++"
+            env1: "CC=clang CXX=clang++"
+          - os: "ubuntu:20.04"
+            pkgs: "gcc-10 g++-10"
+            env1: "CC=gcc-10 CXX=g++-10"
+          - os: "ubuntu:20.04"
+            pkgs: "clang-11"
+            env1: "CC=clang-11 CXX=clang++-11"
+          - os: "alpine"
+            pkgs: "gcc"
+            env1: "CC=gcc CXX=g++"
 
     container:
       image: ${{ matrix.os }}
@@ -63,14 +73,14 @@ jobs:
           zypper -n in ${{ matrix.pkgs }} cmake git go gtest pcre2-devel pkgconfig \
             'pkgconfig(fmt)' 'pkgconfig(libbrotlicommon)' 'pkgconfig(liblz4)' \
             'pkgconfig(libunwind-generic)' 'pkgconfig(libusb-1.0)' \
-            'pkgconfig(libzstd)' 'pkgconfig(protobuf)'
+            'pkgconfig(libzstd)' 'pkgconfig(protobuf)' ninja
 
       - name: prep archlinux
         if: startsWith(matrix.os, 'archlinux')
         run: |
           pacman -Syu --needed --noconfirm \
             ${{ matrix.pkgs }} brotli cmake fmt git go gtest libunwind \
-            libusb lz4 make pcre2 pkgconfig protobuf zstd
+            libusb lz4 pcre2 pkgconfig protobuf zstd ninja
 
       - name: prep ubuntu
         if: startsWith(matrix.os, 'ubuntu')
@@ -79,7 +89,13 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt-get install -yq \
             ${{ matrix.pkgs }} cmake git golang libbrotli-dev libfmt-dev \
             libgtest-dev liblz4-dev libpcre2-dev libprotobuf-dev libunwind-dev \
-            libusb-1.0-0-dev libzstd-dev make pkg-config
+            libusb-1.0-0-dev libzstd-dev pkg-config protobuf-compiler ninja-build
+
+      - name: prep alpine
+        if: startsWith(matrix.os, 'alpine')
+        run: |
+          apk add build-base pcre2-dev linux-headers libusb-dev gtest-dev samurai \
+          go git perl cmake protobuf-dev brotli-dev zstd-dev lz4-dev fmt-dev
 
       # required for patches
       - name: git config
@@ -94,13 +110,11 @@ jobs:
 
       - name: build & install
         run: |
-          test -n "${{ matrix.vars1 }}" && export ${{ matrix.vars1 }}
-          test -n "${{ matrix.vars2 }}" && export ${{ matrix.vars2 }}
+          test -n "${{ matrix.env1 }}" && export ${{ matrix.env1 }}
+          test -n "${{ matrix.env2 }}" && export ${{ matrix.env2 }}
           mkdir build && cd build
-          cmake -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON ..
-          make -O VERBOSE=1 -j
+          cmake -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_BUILD_TYPE=Release -GNinja ..
+          ninja --verbose
           echo -e "\n### make install ###\n"
-          make install
-          echo -e "\n### make package_source ###\n"
-          make package_source
+          ninja install
           echo -e "\n### all done ###\n"


### PR DESCRIPTION
This is a continuation of #35 

Changes over that are, that `package_source` is it's own job and only run ones.
And added an Alpine build job.

It should be fine for now,
I would probably want to add a ppc64le, i686 and some arm* jobs. They are more interesting than 10 more glibc x86_64 builds. (This is google code after all, so expecting to fail 32bit is not unreasonable)

Example runs: https://github.com/Johnnynator/android-tools/actions (Yes, some do currently fail as expected)

Only clang on Ubuntu seems to make some problems (smth, smth can't `#include <span>`), otherwise all Ci runs are successful now. https://github.com/Johnnynator/android-tools/actions/runs/1002453181