### PR TITLE
.github: Attempt to fix ubuntu 20.04 clang build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             pkgs: "gcc-10 g++-10"
             env1: "CC=gcc-10 CXX=g++-10"
           - os: "ubuntu:20.04"
-            pkgs: "clang-11"
+            pkgs: "clang-11 libstdc++-10-dev"
             env1: "CC=clang-11 CXX=clang++-11"
           - os: "alpine"
             pkgs: "gcc"


### PR DESCRIPTION
clang-11 only seems to pull in libstdc++-9-dev, not libstdc++-10-dev.
The former does not seem to have <span> causing the following
compilation error:

	In file included from ../vendor/adb/client/file_sync_client.cpp:46:
	../vendor/adb/compression_utils.h:21:10: fatal error: 'span' file not found
	#include <span>