### PR TITLE
completions: Remove zsh completion files

### DIFF
--- a/completions/CMakeLists.txt
+++ b/completions/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_subdirectory(bash)
-add_subdirectory(zsh)

--- a/completions/zsh/CMakeLists.txt
+++ b/completions/zsh/CMakeLists.txt
@@ -1,9 +1,0 @@
-set(ZSH_COMPLETION_DIR "${CMAKE_INSTALL_FULL_DATADIR}/zsh/site-functions")
-
-configure_file(adb.in _adb)
-configure_file(fastboot.in _fastboot)
-
-install(FILES
-	"${CMAKE_CURRENT_BINARY_DIR}/_adb"
-	"${CMAKE_CURRENT_BINARY_DIR}/_fastboot"
-	DESTINATION "${ZSH_COMPLETION_DIR}")

--- a/completions/zsh/adb.in
+++ b/completions/zsh/adb.in
@@ -1,8 +1,0 @@
-# Bash completions for adb.
-# See https://github.com/nmeum/android-tools/issues/22
-
-function check_type() {
-	type "$1"
-}
-
-source "@COMPLETION_COMMON_DIR@/adb"

--- a/completions/zsh/fastboot.in
+++ b/completions/zsh/fastboot.in
@@ -1,8 +1,0 @@
-# Bash completions for fastboot.
-# See https://github.com/nmeum/android-tools/issues/22
-
-function check_type() {
-	type "$1"
-}
-
-source "@COMPLETION_COMMON_DIR@/fastboot"


### PR DESCRIPTION
Technically, we no longer need to install the common completion file now
as we are only using this file for bash completions. However, this issue
is a blocker for the upcoming platform-tools-31.0.2 release and I don't
want to spend a lot of time fiddling with completion files at this
point in time. The completion setup can still be cleanup up later.

Fixes #38