### PR TITLE
Add boot.img manipulation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Currently the following tools are supported:
 * mke2fs.android (required by fastboot)
 * simg2img, img2simg, append2simg
 * lpdump, lpmake, lpadd, lpflash, lpunpack
+* mkbootimg, unpack_bootimg, repack_bootimg
 
 The build system itself works quite well and is already being used for
 the Alpine Linux [android-tools package][alpine-linux] which I maintain.

--- a/vendor/CMakeLists.mkbootimg.txt
+++ b/vendor/CMakeLists.mkbootimg.txt
@@ -1,0 +1,3 @@
+install(PROGRAMS mkbootimg/mkbootimg.py DESTINATION bin RENAME mkbootimg)
+install(PROGRAMS mkbootimg/unpack_bootimg.py DESTINATION bin RENAME unpack_bootimg)
+install(PROGRAMS mkbootimg/repack_bootimg.py DESTINATION bin RENAME repack_bootimg)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -47,6 +47,7 @@ include(CMakeLists.sparse.txt)
 include(CMakeLists.fastboot.txt)
 include(CMakeLists.mke2fs.txt)
 include(CMakeLists.partition.txt)
+include(CMakeLists.mkbootimg.txt)
 
 # Various C++20 features are used across the codebase, e.g.
 # std::string_view.starts_with. Additionally, GNU extension


### PR DESCRIPTION
Install the already existing (in tree) `mkbootimg`, `unpack_bootimg` and `repack_bootimg` Python scripts as executables.

Any thoughts? Seems to work fine for me locally as tested on Void Linux :)