### PR TITLE
vendor: CMakeLists: Fix cmake pthread use

### DIFF
--- a/vendor/CMakeLists.adb.txt
+++ b/vendor/CMakeLists.adb.txt
@@ -147,9 +147,6 @@ add_library(libcrypto STATIC
 target_include_directories(libcrypto PUBLIC
 	core/libcrypto_utils/include boringssl/include)
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-
 add_executable(adb
 	  adb/adb.cpp
 	  adb/adb_io.cpp

--- a/vendor/CMakeLists.adb.txt
+++ b/vendor/CMakeLists.adb.txt
@@ -147,6 +147,9 @@ add_library(libcrypto STATIC
 target_include_directories(libcrypto PUBLIC
 	core/libcrypto_utils/include boringssl/include)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 add_executable(adb
 	  adb/adb.cpp
 	  adb/adb_io.cpp
@@ -191,7 +194,7 @@ target_link_libraries(adb
 	brotlidec
 	brotlienc
 	lz4
-	pthread
+	Threads::Threads
 	usb-1.0
 	z
 	zstd)

--- a/vendor/CMakeLists.fastboot.txt
+++ b/vendor/CMakeLists.fastboot.txt
@@ -109,9 +109,6 @@ add_library(libsepol
 target_include_directories(libsepol PUBLIC
 	selinux/libsepol/include)
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-
 add_executable(fastboot
 	core/fastboot/bootimg_utils.cpp
 	core/fastboot/fastboot.cpp

--- a/vendor/CMakeLists.fastboot.txt
+++ b/vendor/CMakeLists.fastboot.txt
@@ -109,6 +109,9 @@ add_library(libsepol
 target_include_directories(libsepol PUBLIC
 	selinux/libsepol/include)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 add_executable(fastboot
 	core/fastboot/bootimg_utils.cpp
 	core/fastboot/fastboot.cpp
@@ -135,4 +138,4 @@ target_compile_definitions(fastboot PRIVATE
 target_link_libraries(fastboot
 	libsparse libzip libcutils liblog libfsmgr libutil
 	libbase libext4 libselinux libsepol libdiagnoseusb crypto
-	z pcre2-8 pthread dl)
+	z pcre2-8 Threads::Threads dl)

--- a/vendor/CMakeLists.mke2fs.txt
+++ b/vendor/CMakeLists.mke2fs.txt
@@ -106,9 +106,6 @@ add_library(libext2fs STATIC
 target_include_directories(libext2fs PRIVATE
 	e2fsprogs/lib e2fsprogs/lib/ext2fs core/libsparse/include)
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-
 add_executable("${ANDROID_MKE2FS_NAME}"
 	e2fsprogs/misc/default_profile.c
 	e2fsprogs/misc/mke2fs.c

--- a/vendor/CMakeLists.mke2fs.txt
+++ b/vendor/CMakeLists.mke2fs.txt
@@ -106,6 +106,9 @@ add_library(libext2fs STATIC
 target_include_directories(libext2fs PRIVATE
 	e2fsprogs/lib e2fsprogs/lib/ext2fs core/libsparse/include)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 add_executable("${ANDROID_MKE2FS_NAME}"
 	e2fsprogs/misc/default_profile.c
 	e2fsprogs/misc/mke2fs.c
@@ -113,6 +116,6 @@ add_executable("${ANDROID_MKE2FS_NAME}"
 	e2fsprogs/misc/util.c)
 
 target_link_libraries("${ANDROID_MKE2FS_NAME}"
-	libext2fs libsparse libbase libzip liblog libutil pthread z)
+	libext2fs libsparse libbase libzip liblog libutil Threads::Threads z)
 target_include_directories("${ANDROID_MKE2FS_NAME}" PRIVATE
 	e2fsprogs/lib)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -37,6 +37,8 @@ endif()
 add_subdirectory(boringssl EXCLUDE_FROM_ALL)
 add_subdirectory(fmtlib EXCLUDE_FROM_ALL)
 find_package(Protobuf REQUIRED)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 include_directories(${PROTOBUF_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
Let cmake use -pthread instead of -lpthread, to fix build error on riscv.

FYI:
stackoverflow.com/questions/23250863/difference-between-pthread-and-lpthread-while-compiling
stackoverflow.com/questions/1620918/cmake-and-libpthread
cmake.org/cmake/help/latest/module/FindThreads.html#variable:THREADS_PREFER_PTHREAD_FLAG