### PR TITLE
README.md: Mention Python 3 as a required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The following libraries are required by android-tools:
 5. [brotli][brotli]
 6. [zstd][zstd]
 7. [lz4][lz4]
+8. [Python 3][py3]
 
 Additionally the following software is required at compile-time:
 
@@ -110,4 +111,5 @@ have been copied from Anatol's ruby script.
 [brotli]: https://github.com/google/brotli
 [zstd]: https://facebook.github.io/zstd/
 [lz4]: https://github.com/lz4/lz4
+[py3]: https://www.python.org/
 [anatol.pomozov]: https://github.com/anatol


### PR DESCRIPTION
This is needed by the `mkbootimg`, `repack_bootimg` and `unpack_bootimg` tools.