### PR TITLE
boringssl: Add support for RISC-V 64-bit architecture

### DIFF
--- a/patches/boringssl/0012-Add-support-for-RISC-V-64-bit-architecture.patch
+++ b/patches/boringssl/0012-Add-support-for-RISC-V-64-bit-architecture.patch
@@ -1,0 +1,44 @@
+From b7204f778ac8a1528af2e70413eb9221a0e91d38 Mon Sep 17 00:00:00 2001
+From: Rebecca Chang Swee Fun <rebecca.chang@starfivetech.com>
+Date: Thu, 2 Jun 2022 07:18:58 +0000
+Subject: [PATCH] Add support for RISC-V 64-bit architecture
+
+Signed-off-by: Rebecca Chang Swee Fun <rebecca.chang@starfivetech.com>
+Change-Id: If6424a3b268943a5e2dc847f94b509d4b509df79
+Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/52765
+Commit-Queue: Adam Langley <agl@google.com>
+Reviewed-by: Adam Langley <agl@google.com>
+---
+ CMakeLists.txt         | 2 ++
+ include/openssl/base.h | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f58e853cd..26ee8c129 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -498,6 +498,8 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "mips")
+   set(ARCH "generic")
+ elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
+   set(ARCH "ppc64le")
++elseif (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "riscv64")
++  set(ARCH "riscv64")
+ else()
+   message(FATAL_ERROR "Unknown processor:" ${CMAKE_SYSTEM_PROCESSOR})
+ endif()
+diff --git a/include/openssl/base.h b/include/openssl/base.h
+index 90924e629..04d04e1c6 100644
+--- a/include/openssl/base.h
++++ b/include/openssl/base.h
+@@ -114,6 +114,8 @@ extern "C" {
+ #define OPENSSL_32_BIT
+ #elif defined(__myriad2__)
+ #define OPENSSL_32_BIT
++#elif defined(__riscv) && __riscv_xlen == 64
++#define OPENSSL_64_BIT
+ #else
+ // Note BoringSSL only supports standard 32-bit and 64-bit two's-complement,
+ // little-endian architectures. Functions will not produce the correct answer
+-- 
+2.37.0
+


### PR DESCRIPTION
Hi! I'm building this package for ArchLinux RISC-V distribution and I get an error message:

```
-- Checking for module 'libunwind-generic'
--   Package 'libunwind-generic', required by 'virtual:world', not found
libunwind not found. Disabling unwind tests.
CMake Error at vendor/boringssl/CMakeLists.txt:502 (message):
  Unknown processor:riscv64
```

`boringssl` has supported RISC-V 64 architecture in [this commit](https://boringssl.googlesource.com/boringssl/+/4566bb5fe517f7f141b5fe935c559fc4311af35d). This PR brings it to the patch set of this package to support compiling it for RISC-V 64 architecture.

And since `git am` doesn't support fuzzy patching, this patch cannot be applied by `git am` directly, I replaced it with `patch` command, it shouldn't ruin the previous work, and avoid depending on `git` for this purpose.