### PR TITLE
Minor cmake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(android-tools)
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.12.0)
 
 # To ease installation of utility files such as bash completions, etc.
 # See: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,5 +1,4 @@
-# TODO: https://cmake.org/cmake/help/v3.0/module/ExternalProject.html
-# To patch the submodule
+enable_language(C CXX)
 
 set(android-vendored
 	avb
@@ -18,6 +17,7 @@ set(android-vendored
 	fmtlib
 	boringssl)
 
+# XXX: Consider using https://cmake.org/cmake/help/v3.0/module/ExternalProject.html
 if(EXISTS "${ANDROID_PATCH_DIR}/")
 	execute_process(COMMAND git submodule --quiet update)
 	foreach(v ${android-vendored})

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,5 +1,15 @@
 enable_language(C CXX)
 
+# Use C11 with GNU extensions.
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_EXTENSIONS ON)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Use C++20 with GNU extensions.
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_EXTENSIONS ON)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(android-vendored
 	avb
 	adb
@@ -52,12 +62,6 @@ include(CMakeLists.fastboot.txt)
 include(CMakeLists.mke2fs.txt)
 include(CMakeLists.partition.txt)
 include(CMakeLists.mkbootimg.txt)
-
-# Various C++20 features are used across the codebase, e.g.
-# std::string_view.starts_with. Additionally, GNU extension
-# (such as typeof) are used occasionally.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++2a")
 
 # Android seems to use various attributes supported by clang but not by
 # GCC which causes it to emit lots of warnings. Since these attributes

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -88,7 +88,7 @@ install(TARGETS
 	lpunpack
 	simg2img
 	e2fsdroid
-	ext2simg 
+	ext2simg
 	DESTINATION bin)
 
 # Install common completion files.

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -10,6 +10,15 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Android seems to use various attributes supported by clang but not by
+# GCC which causes it to emit lots of warnings. Since these attributes
+# don't seem to effect runtime behaviour simply disable the warnings.
+add_compile_options(-Wno-attributes)
+
+# libfsmgr (required by fastboot) requires a 64-bit off_t for lseek. On
+# 32-bit glibc platforms this is not the case by default.
+add_compile_definitions(_FILE_OFFSET_BITS=64)
+
 set(android-vendored
 	avb
 	adb
@@ -62,17 +71,6 @@ include(CMakeLists.fastboot.txt)
 include(CMakeLists.mke2fs.txt)
 include(CMakeLists.partition.txt)
 include(CMakeLists.mkbootimg.txt)
-
-# Android seems to use various attributes supported by clang but not by
-# GCC which causes it to emit lots of warnings. Since these attributes
-# don't seem to effect runtime behaviour simply disable the warnings.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-attributes")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
-
-# libfsmgr (required by fastboot) requires a 64-bit off_t for lseek. On
-# 32-bit glibc platforms this is not the case by default.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FILE_OFFSET_BITS=64")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FILE_OFFSET_BITS=64")
 
 # Targets which should be installed by `make install`.
 install(TARGETS


### PR DESCRIPTION
* Set language standard via `CMAKE_C_STANDARD` and `CMAKE_CXX_STANDARD` standard
* Use new [`add_compile_options`](https://cmake.org/cmake/help/latest/command/add_compile_options.html) and [`add_compile_definitions`](https://cmake.org/cmake/help/latest/command/add_compile_definitions.html)
    * Instead of modifying both C and C++ flags directly
* Bump required CMake version to >= 3.12