### PR TITLE
Add mkdtboimg tool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,6 @@
 	shallow = true
 	path = vendor/fmtlib
 	url = https://android.googlesource.com/platform/external/fmtlib.git
+[submodule "vendor/libufdt"]
+	path = vendor/libufdt
+	url = https://android.googlesource.com/platform/system/libufdt.git

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Currently the following tools are supported:
 * simg2img, img2simg, append2simg
 * lpdump, lpmake, lpadd, lpflash, lpunpack
 * mkbootimg, unpack_bootimg, repack_bootimg
+* mkdtboimg
 
 The build system itself works quite well and is already being used for
 the Alpine Linux [android-tools package][alpine-linux] which I maintain.

--- a/vendor/CMakeLists.libufdt.txt
+++ b/vendor/CMakeLists.libufdt.txt
@@ -1,0 +1,1 @@
+install(PROGRAMS libufdt/utils/src/mkdtboimg.py DESTINATION bin RENAME mkdtboimg)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -71,6 +71,7 @@ include(CMakeLists.fastboot.txt)
 include(CMakeLists.mke2fs.txt)
 include(CMakeLists.partition.txt)
 include(CMakeLists.mkbootimg.txt)
+include(CMakeLists.libufdt.txt)
 
 # Targets which should be installed by `make install`.
 install(TARGETS


### PR DESCRIPTION
This is a tool for packing multiple DTB/DTBO files into a single image which is used by bootloader on various Android devices since circa 2017.

`libufdt` is now tracking tag [`platform-tools-33.0.3`](https://android.googlesource.com/platform/system/libufdt/+/refs/tags/platform-tools-33.0.3) as #65 has been merged.