### PR TITLE
Fix mkbootimg since 33.0.3 upgrade

### DIFF
--- a/vendor/CMakeLists.mkbootimg.txt
+++ b/vendor/CMakeLists.mkbootimg.txt
@@ -1,3 +1,9 @@
-install(PROGRAMS mkbootimg/mkbootimg.py DESTINATION bin RENAME mkbootimg)
+set(MKBOOTIMG_SCRIPTS_DIR "${CMAKE_INSTALL_FULL_DATADIR}/android-tools/mkbootimg")
+install(PROGRAMS mkbootimg/mkbootimg.py DESTINATION ${MKBOOTIMG_SCRIPTS_DIR})
+add_custom_target(mkbootimg_symlink ALL COMMAND ${CMAKE_COMMAND} -E create_symlink
+	${MKBOOTIMG_SCRIPTS_DIR}/mkbootimg.py
+	${CMAKE_CURRENT_BINARY_DIR}/mkbootimg)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mkbootimg DESTINATION bin)
+install(FILES mkbootimg/gki/generate_gki_certificate.py DESTINATION ${MKBOOTIMG_SCRIPTS_DIR}/gki)
 install(PROGRAMS mkbootimg/unpack_bootimg.py DESTINATION bin RENAME unpack_bootimg)
 install(PROGRAMS mkbootimg/repack_bootimg.py DESTINATION bin RENAME repack_bootimg)


### PR DESCRIPTION
It now requires an import of a `gki/generate_gki_certificate.py`, so install the scripts in `/usr/share/android-tools/mkbootimg` and symlink back to `/usr/bin/mkbootimg` to avoid having to patch anything.

Suggestions for a better way to create the symlink are welcome, I'm not entirely happy with it, but it does work :)

Fixes #76.