### PR TITLE
Add avbtool for working with Android Verified Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Currently the following tools are supported:
 * mke2fs.android (required by fastboot)
 * simg2img, img2simg, append2simg
 * lpdump, lpmake, lpadd, lpflash, lpunpack
-* mkbootimg, unpack_bootimg, repack_bootimg
+* mkbootimg, unpack_bootimg, repack_bootimg, avbtool
 * mkdtboimg
 
 The build system itself works quite well and is already being used for

--- a/vendor/CMakeLists.avb.txt
+++ b/vendor/CMakeLists.avb.txt
@@ -1,0 +1,1 @@
+install(PROGRAMS avb/avbtool.py DESTINATION bin RENAME avbtool)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -72,6 +72,7 @@ include(CMakeLists.mke2fs.txt)
 include(CMakeLists.partition.txt)
 include(CMakeLists.mkbootimg.txt)
 include(CMakeLists.libufdt.txt)
+include(CMakeLists.avb.txt)
 
 # Targets which should be installed by `make install`.
 install(TARGETS


### PR DESCRIPTION
It's also an additional requirement to use the (already deprecated?!) [GKI 2.0 signing arguments](https://android.googlesource.com/platform/system/tools/mkbootimg/+/339274e/mkbootimg.py#555) with `mkbootimg`.

Fixes #77.