### PR TITLE
vendor: add mkbootimg & libufdt to android-vendored variable

### DIFF
--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -26,8 +26,10 @@ set(android-vendored
 	core
 	extras
 	libbase
+	libufdt
 	libziparchive
 	logging
+	mkbootimg
 	native
 	selinux
 	f2fs-tools


### PR DESCRIPTION
See [`.gitmodules`](https://github.com/nmeum/android-tools/blob/master/.gitmodules).