### PR TITLE
CMake: Fix cmake_minimum_required() call location warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(android-tools)
 cmake_minimum_required(VERSION 3.12.0)
+project(android-tools)
 
 # To ease installation of utility files such as bash completions, etc.
 # See: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html


### PR DESCRIPTION
```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
```