### PR TITLE
Import <algorithm> to build on GCC 14

### DIFF
--- a/patches/adb/0025-Add-explicit-import-for-algorithm.patch
+++ b/patches/adb/0025-Add-explicit-import-for-algorithm.patch
@@ -1,0 +1,26 @@
+From 959eb4a096fc51bf2814e3374cb12b41d32a045d Mon Sep 17 00:00:00 2001
+From: Christopher Fore <csfore@posteo.net>
+Date: Mon, 20 Nov 2023 14:13:24 -0500
+Subject: [PATCH] adb: IWYU, include <algorithm> for std::remove_if
+
+GCC 14 starts to no longer include <algorithm> by default, resulting in
+it needing to be explicitly declared.
+
+Test: Recompiled with GCC 14 and succeeded
+
+Change-Id: I1ff332284aa3b5dd38f882f9519269c9d370798c
+Signed-off-by: Christopher Fore <csfore@posteo.net>
+---
+
+diff --git a/client/incremental_utils.cpp b/client/incremental_utils.cpp
+index 2f6958b..67f21a1 100644
+--- a/client/incremental_utils.cpp
++++ b/client/incremental_utils.cpp
+@@ -24,6 +24,7 @@
+ #include <ziparchive/zip_archive.h>
+ #include <ziparchive/zip_writer.h>
+ 
++#include <algorithm>
+ #include <array>
+ #include <cinttypes>
+ #include <numeric>

--- a/patches/core/0012-Add-explicit-import-for-algorithm.patch
+++ b/patches/core/0012-Add-explicit-import-for-algorithm.patch
@@ -1,0 +1,26 @@
+From 1f8bbf8c3dd76401b09de9af7e94d6099589a965 Mon Sep 17 00:00:00 2001
+From: Christopher Fore <csfore@posteo.net>
+Date: Mon, 20 Nov 2023 15:19:12 -0500
+Subject: [PATCH] fs_mgr: IWYU include <algorithm> for std::sort
+
+GCC 14 starts to no longer include <algorithm> by default, resulting in
+it needing to be explicitly declared.
+
+Test: Recompiled with GCC 14 and succeeded
+
+Change-Id: Ifc5dd58b7476ba728ae604cd2924cb68fbcab701
+Signed-off-by: Christopher Fore <csfore@posteo.net>
+---
+
+diff --git a/fs_mgr/liblp/include/liblp/liblp.h b/fs_mgr/liblp/include/liblp/liblp.h
+index 04f8987..c42dcdc 100644
+--- a/fs_mgr/liblp/include/liblp/liblp.h
++++ b/fs_mgr/liblp/include/liblp/liblp.h
+@@ -20,6 +20,7 @@
+ #include <stddef.h>
+ #include <stdint.h>
+ 
++#include <algorithm>
+ #include <map>
+ #include <memory>
+ #include <string>


### PR DESCRIPTION
By default GCC 14 no longer includes <algorithm>, so it has to be explicitly imported now.