### PR TITLE
Don't use absolute dir for mkbootimg symlink

### DIFF
--- a/vendor/CMakeLists.mkbootimg.txt
+++ b/vendor/CMakeLists.mkbootimg.txt
@@ -1,7 +1,7 @@
-set(MKBOOTIMG_SCRIPTS_DIR ${CMAKE_INSTALL_FULL_DATADIR}/android-tools/mkbootimg)
+set(MKBOOTIMG_SCRIPTS_DIR ${CMAKE_INSTALL_DATADIR}/android-tools/mkbootimg)
 install(PROGRAMS mkbootimg/mkbootimg.py DESTINATION ${MKBOOTIMG_SCRIPTS_DIR})
 add_custom_target(mkbootimg_symlink ALL COMMAND ${CMAKE_COMMAND} -E create_symlink
-	${MKBOOTIMG_SCRIPTS_DIR}/mkbootimg.py
+	../${MKBOOTIMG_SCRIPTS_DIR}/mkbootimg.py
 	${CMAKE_CURRENT_BINARY_DIR}/mkbootimg)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mkbootimg DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES mkbootimg/gki/generate_gki_certificate.py DESTINATION ${MKBOOTIMG_SCRIPTS_DIR}/gki)

--- a/vendor/CMakeLists.mkbootimg.txt
+++ b/vendor/CMakeLists.mkbootimg.txt
@@ -1,9 +1,9 @@
-set(MKBOOTIMG_SCRIPTS_DIR "${CMAKE_INSTALL_FULL_DATADIR}/android-tools/mkbootimg")
+set(MKBOOTIMG_SCRIPTS_DIR ${CMAKE_INSTALL_FULL_DATADIR}/android-tools/mkbootimg)
 install(PROGRAMS mkbootimg/mkbootimg.py DESTINATION ${MKBOOTIMG_SCRIPTS_DIR})
 add_custom_target(mkbootimg_symlink ALL COMMAND ${CMAKE_COMMAND} -E create_symlink
 	${MKBOOTIMG_SCRIPTS_DIR}/mkbootimg.py
 	${CMAKE_CURRENT_BINARY_DIR}/mkbootimg)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mkbootimg DESTINATION bin)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mkbootimg DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES mkbootimg/gki/generate_gki_certificate.py DESTINATION ${MKBOOTIMG_SCRIPTS_DIR}/gki)
-install(PROGRAMS mkbootimg/unpack_bootimg.py DESTINATION bin RENAME unpack_bootimg)
-install(PROGRAMS mkbootimg/repack_bootimg.py DESTINATION bin RENAME repack_bootimg)
+install(PROGRAMS mkbootimg/unpack_bootimg.py DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME unpack_bootimg)
+install(PROGRAMS mkbootimg/repack_bootimg.py DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME repack_bootimg)


### PR DESCRIPTION
I noticed that the absolute symlink did not work on my system.
While investigating I noticed that on SUSE the symlink gets relinked
to be relative to be relative to the install location of the symlink
after which the link works.
Using a relative link seems safer to me.