### PR TITLE
CI: Add macos-14 in build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,16 +153,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     needs: [upload-src]
     steps:
       - name: prep macos
         run: |
-          brew uninstall "openssl@1.1"
-          rm /usr/local/bin/openssl
-          rm -rf /usr/local/opt/openssl /usr/local/include/openssl
-          brew install --overwrite brotli cmake go googletest libusb lz4 \
+          rm -rf /opt/homebrew/include/openssl /usr/local/opt/openssl /usr/local/include/openssl
+          brew install --overwrite --quiet brotli cmake go googletest libusb lz4 \
           ninja pcre2 protobuf zstd
 
       - name: download source
@@ -175,15 +173,16 @@ jobs:
           tar -xf android-tools-*.tar.xz
           cd android-tools-*/
           mkdir build && cd build
-          cmake -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_BUILD_TYPE=Release -GNinja ..
+          cmake -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=$HOME/android-tools -GNinja ..
           ninja --verbose
           echo -e "\n### make install ###\n"
-          cmake --install . --prefix /usr/local
+          cmake --install .
           echo -e "\n### all done ###\n"
 
       - name: check
         run: |
-          /usr/local/bin/adb --version
-          /usr/local/bin/fastboot --version
-          /usr/local/bin/make_f2fs -V
-          /usr/local/bin/sload_f2fs -V
+          $HOME/android-tools/bin/adb --version
+          $HOME/android-tools/bin/fastboot --version
+          $HOME/android-tools/bin/make_f2fs -V
+          $HOME/android-tools/bin/sload_f2fs -V

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     needs: [upload-src]
     steps:


### PR DESCRIPTION

    * Do not uninstall openssl@1.1 to prevent various warnings.
    
    * Remove only openssl include directory. /opt/homebrew/include/openssl
      directory is present in macos-14 runner only.
    
    * Add quiet option with brew install command to suppress some warnings as following.
    
      brotli 1.1.0 is already installed and up-to-date. To reinstall 1.1.0, run: brew reinstall brotli
      cmake 3.29.3 is already installed and up-to-date. To reinstall 3.29.3, run: brew reinstall cmake
      etc.
    
    * Change install prefix to HOME/android-tools because cmake
      can not install in /usr/local directory in macos-14. The
      error is as following.
    
      CMake Error at completions/bash/cmake_install.cmake:49 (file):
      file cannot create directory: /usr/local/share/bash-completion/completions.
      Maybe need administrative privileges.
