### PR TITLE
adb: Add support for ANDROID_USER_HOME env var

### DIFF
--- a/patches/adb/0027-Add-support-for-ANDROID_USER_HOME-env-var.patch
+++ b/patches/adb/0027-Add-support-for-ANDROID_USER_HOME-env-var.patch
@@ -1,0 +1,33 @@
+From fc6283aae98cfcc1d15cb352e381f79ba4eda466 Mon Sep 17 00:00:00 2001
+From: Nikolaos Karaolidis <nick@karaolidis.com>
+Date: Wed, 24 Jul 2024 13:58:39 +0100
+Subject: [PATCH] Add support for ANDROID_USER_HOME env var
+
+Signed-off-by: Nikolaos Karaolidis <nick@karaolidis.com>
+---
+ adb_utils.cpp | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/adb_utils.cpp b/adb_utils.cpp
+index d1910f1..f4e5a1c 100644
+--- a/adb_utils.cpp
++++ b/adb_utils.cpp
+@@ -308,8 +308,16 @@ std::string adb_get_homedir_path() {
+ }
+ 
+ std::string adb_get_android_dir_path() {
+-    std::string user_dir = adb_get_homedir_path();
+-    std::string android_dir = user_dir + OS_PATH_SEPARATOR + ".android";
++    const char* android_user_home = getenv("ANDROID_USER_HOME");
++    std::string android_dir;
++
++    if (android_user_home) {
++        android_dir = std::string(android_user_home);
++    } else {
++        std::string user_dir = adb_get_homedir_path();
++        android_dir = user_dir + OS_PATH_SEPARATOR + ".android";
++    }
++
+     struct stat buf;
+     if (stat(android_dir.c_str(), &buf) == -1) {
+         if (adb_mkdir(android_dir, 0750) == -1) {


### PR DESCRIPTION
Doing `alias adb='HOME=$XDG_DATA_HOME/android adb'` is too ugly :)