### PR TITLE
CMake: Add option to use system fmt library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
       - name: build & install
         run: |
           mkdir build && cd build
-          cmake ..
+          cmake \
+            -DANDROID_TOOLS_USE_BUNDLED_FMT=ON \
+            ..
           make package_source
           for x in sha1sum sha256sum sha512sum b2sum; do
             printf "$x " && $x ${{ github.workspace }}/build/android-tools-*.tar.xz | cut -d " " -f 1
@@ -140,7 +142,13 @@ jobs:
           test -n "${{ matrix.env1 }}" && export ${{ matrix.env1 }}
           test -n "${{ matrix.env2 }}" && export ${{ matrix.env2 }}
           mkdir build && cd build
-          cmake -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_BUILD_TYPE=Release -GNinja ..
+          cmake \
+            -DCMAKE_C_FLAGS="$CFLAGS" \
+            -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DANDROID_TOOLS_USE_BUNDLED_FMT=ON \
+            -GNinja \
+            ..
           ninja --verbose
           echo -e "\n### make install ###\n"
           cmake --install . --prefix /usr/local
@@ -184,8 +192,14 @@ jobs:
           tar -xf android-tools-*.tar.xz
           cd android-tools-*/
           mkdir build && cd build
-          cmake -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX=$HOME/android-tools -GNinja ..
+          cmake \
+            -DCMAKE_C_FLAGS="$CFLAGS" \
+            -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=$HOME/android-tools \
+            -DANDROID_TOOLS_USE_BUNDLED_FMT=ON \
+            -GNinja \
+            ..
           ninja --verbose
           echo -e "\n### make install ###\n"
           cmake --install .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ include(GNUInstallDirs)
 # This helps to build vendor projects with or without any patching. Also if any
 # files are changed in vendor projects those can be retained with this option.
 option(ANDROID_TOOLS_PATCH_VENDOR "Patch vendor projects using patches directory" ON)
+option(ANDROID_TOOLS_USE_BUNDLED_FMT "Use bundled fmt library instead of system provided one" OFF)
 
 # Install bash/zsh completion files.
 set(COMPLETION_COMMON_DIR "${CMAKE_INSTALL_FULL_DATADIR}/android-tools/completions")

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -75,7 +75,13 @@ if(ANDROID_TOOLS_PATCH_VENDOR AND EXISTS "${ANDROID_PATCH_DIR}/")
 endif()
 
 add_subdirectory(boringssl EXCLUDE_FROM_ALL)
-add_subdirectory(fmtlib EXCLUDE_FROM_ALL)
+
+if(ANDROID_TOOLS_USE_BUNDLED_FMT)
+	add_subdirectory(fmtlib EXCLUDE_FROM_ALL)
+else()
+	find_package(fmt CONFIG REQUIRED)
+	message(STATUS "Found fmt: ${fmt_DIR} (version ${fmt_VERSION})")
+endif()
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(libbrotlicommon REQUIRED IMPORTED_TARGET libbrotlicommon)


### PR DESCRIPTION
fmt library was added in vendor in 21061c1dfb006c22304053c1f6f9e48ae4cbe25a commit for systems with older fmt versions. Now, distributions can choose to link with their own fmt shared library or use the bundled one.