### PR TITLE
CI: Add protobuf-compiler dependency for ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
             ${{ matrix.pkgs }} cmake git golang libbrotli-dev \
             libgtest-dev liblz4-dev libpcre2-dev libprotobuf-dev libunwind-dev \
-            libzstd-dev make pandoc pkg-config xz-utils
+            libzstd-dev make pandoc pkg-config protobuf-compiler xz-utils
       - name: checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This fixes the previous CI failure https://github.com/nmeum/android-tools/actions/runs/11862558771/job/33062200632