### PR TITLE
Fix missing whitespace in patches

### DIFF
--- a/patches/adb/0023-Update-usage-of-usbdevfs_urb-to-match-new-kernel-UAP.patch
+++ b/patches/adb/0023-Update-usage-of-usbdevfs_urb-to-match-new-kernel-UAP.patch
@@ -49,7 +49,7 @@ index 7f926266..235a21be 100644
 +    usbdevfs_urb *urb_in;
 +    usbdevfs_urb *urb_out;
  #pragma clang diagnostic pop
-
+ 
      bool urb_in_busy = false;
 @@ -303,7 +303,7 @@ static int usb_bulk_write(usb_handle* h, const void* data, int len) {
      std::unique_lock<std::mutex> lock(h->mutex);

--- a/patches/core/0009-Don-t-use-the-internal-glibc-header-sys-cdefs.h.patch
+++ b/patches/core/0009-Don-t-use-the-internal-glibc-header-sys-cdefs.h.patch
@@ -505,23 +505,23 @@ index dbaeb93..0cc119c 100644
 @@ -24,7 +23,9 @@
  #include <string_view>
  #include <vector>
-
+ 
 -__BEGIN_DECLS
 +#ifdef __cplusplus
 +extern "C" {
 +#endif
-
+ 
  static constexpr const char* CGROUPV2_HIERARCHY_NAME = "cgroup2";
  [[deprecated]] static constexpr const char* CGROUPV2_CONTROLLER_NAME = "cgroup2";
 @@ -40,7 +41,9 @@ bool SetTaskProfiles(pid_t tid, const std::vector<std::string>& profiles,
  bool SetProcessProfiles(uid_t uid, pid_t pid, const std::vector<std::string>& profiles);
  bool SetUserProfiles(uid_t uid, const std::vector<std::string>& profiles);
-
+ 
 -__END_DECLS
 +#ifdef __cplusplus
 +}
 +#endif
-
+ 
  bool SetTaskProfiles(pid_t tid, std::initializer_list<std::string_view> profiles,
                       bool use_fd_cache = false);
 @@ -49,7 +52,9 @@ bool SetTaskProfiles(int tid, std::span<const std::string_view> profiles,
@@ -880,12 +880,12 @@ index 16207e6..9a12458 100644
 @@ -20,7 +20,9 @@
  #include <keymaster/android_keymaster_messages.h>
  #include <trusty_keymaster/ipc/keymaster_ipc.h>
-
+ 
 -__BEGIN_DECLS
 +#ifdef __cplusplus
 +extern "C" {
 +#endif
-
+ 
  const uint32_t TRUSTY_KEYMASTER_RECV_BUF_SIZE = 2 * 4096;
  const uint32_t TRUSTY_KEYMASTER_SEND_BUF_SIZE =
 @@ -35,6 +37,8 @@ keymaster_error_t translate_error(int err);

--- a/patches/core/0011-core-include-missing-headers.patch
+++ b/patches/core/0011-core-include-missing-headers.patch
@@ -27,11 +27,11 @@ index 7cb8a6b..070c8b0 100644
 @@ -15,6 +15,8 @@
  //
  #pragma once
-
+ 
 +#include <stdint.h>
 +
  #include <string>
-
+ 
  #include "android-base/unique_fd.h"
 --
 2.40.1

--- a/patches/libbase/0002-remove-glibc-internal-headers-cdefs.h.patch
+++ b/patches/libbase/0002-remove-glibc-internal-headers-cdefs.h.patch
@@ -14,22 +14,22 @@ index b47494b..c29845e 100644
 +++ b/include/android-base/endian.h
 @@ -19,7 +19,7 @@
  /* A cross-platform equivalent of bionic's <sys/endian.h>. */
-
+ 
  /* For __BIONIC__ and __GLIBC__ */
 -#include <sys/cdefs.h>
 +#include <cfloat>
-
+ 
  #if defined(__BIONIC__)
-
+ 
 diff --git a/include/android-base/properties.h b/include/android-base/properties.h
 index 021f466..53b8ea1 100644
 --- a/include/android-base/properties.h
 +++ b/include/android-base/properties.h
 @@ -16,7 +16,6 @@
-
+ 
  #pragma once
-
+ 
 -#include <sys/cdefs.h>
-
+ 
  #include <chrono>
  #include <limits>


### PR DESCRIPTION
Such patches may be technically invalid. These errors also mess with `git patch-id`, which is undesirable.