### PR TITLE
Add missing <cstdint> includes for GCC 16 (Fedora Rawhide affected)

### DIFF
--- a/patches/libbase/0007-Include-missing-cstdint-header.patch
+++ b/patches/libbase/0007-Include-missing-cstdint-header.patch
@@ -1,0 +1,29 @@
+From 4fedf25206c442d655d21e95e6ec5557383db006 Mon Sep 17 00:00:00 2001
+From: meator <meator.dev@gmail.com>
+Date: Wed, 14 Jan 2026 11:57:22 +0100
+Subject: [PATCH] Include missing cstdint header
+
+This code relied on the fact that some system headers pulled <cstdint>,
+so it did not bother to include it itself. However, this behavior is not
+specified, so compiler updates can break the code by no longer including
+this header.
+---
+ hex.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/hex.cpp b/hex.cpp
+index a4b7715..c46f42d 100644
+--- a/hex.cpp
++++ b/hex.cpp
+@@ -18,6 +18,8 @@
+ 
+ #include "android-base/logging.h"
+ 
++#include <cstdint>
++
+ namespace android {
+ namespace base {
+ 
+-- 
+2.51.2
+

--- a/patches/libziparchive/0002-Include-missing-cstdint-header.patch
+++ b/patches/libziparchive/0002-Include-missing-cstdint-header.patch
@@ -1,0 +1,28 @@
+From b34e48bd2ac596d5d92ee77ee5cb040399b4466a Mon Sep 17 00:00:00 2001
+From: meator <meator.dev@gmail.com>
+Date: Wed, 14 Jan 2026 12:13:37 +0100
+Subject: [PATCH] Include missing cstdint header
+
+This code relied on the fact that some system headers pulled <cstdint>,
+so it did not bother to include it itself. However, this behavior is not
+specified, so compiler updates can break the code by no longer including
+this header.
+---
+ include/ziparchive/zip_writer.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/ziparchive/zip_writer.h b/include/ziparchive/zip_writer.h
+index 268e8b6..c85be2a 100644
+--- a/include/ziparchive/zip_writer.h
++++ b/include/ziparchive/zip_writer.h
+@@ -18,6 +18,7 @@
+ 
+ #include <cstdio>
+ #include <ctime>
++#include <cstdint>
+ 
+ #include <gtest/gtest_prod.h>
+ #include <memory>
+-- 
+2.51.2
+


### PR DESCRIPTION
These errors can be observed in the latest CI runs of android-tools: https://github.com/nmeum/android-tools/actions/runs/20953732932

I have observed them because they caused issues in CI of my fork of android-tools: https://github.com/meator/android-tools-static/actions/runs/20990317521

Also, I would greatly appreciate if any of the maintainers here would react to https://github.com/nmeum/android-tools/discussions/187 Unlike nmeum/android-tools, which has some problems building for all CI targets, my fork passes CI (except for the issue fixed by this PR + macos 13 deprecation).