### PR TITLE
Drop gcc11-c++ dependency from opensuse/leap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - os: "opensuse/leap:latest"
-            pkgs: "clang gcc11-c++"
+            pkgs: "clang"
             env1: "CC=clang CXX=clang++"
           - os: "opensuse/tumbleweed"
             pkgs: "gcc gcc-c++"


### PR DESCRIPTION
It's not installable and CC/CXX are set to clang anyway.