### PR TITLE
README.md, CI: Remove golang usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         include:
           - os: "opensuse/leap:latest"
-            pkgs: "clang"
+            pkgs: "clang gcc"
             env1: "CC=clang CXX=clang++"
           - os: "opensuse/tumbleweed"
             pkgs: "gcc gcc-c++"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,9 @@ jobs:
         run: |
           sudo apt-get update
           DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
-            ${{ matrix.pkgs }} cmake git golang libbrotli-dev \
+            ${{ matrix.pkgs }} cmake git libbrotli-dev \
             libgtest-dev liblz4-dev libpcre2-dev libprotobuf-dev libunwind-dev \
             libzstd-dev make pandoc pkg-config protobuf-compiler xz-utils
-      - name: setup go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.24" # from vendor/boringssl/go.mod
       - name: checkout
         uses: actions/checkout@v7
         with:
@@ -26,10 +22,6 @@ jobs:
         run: |
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
-      - name: get vendor modules
-        run: |
-          cd vendor/boringssl
-          go mod vendor
       - name: generate man page
         run: |
           cd vendor/adb/docs/user
@@ -101,7 +93,7 @@ jobs:
         if: startsWith(matrix.os, 'opensuse')
         run: |
           zypper -n ref
-          zypper -n in ${{ matrix.pkgs }} cmake git go gtest pcre2-devel pkgconfig \
+          zypper -n in ${{ matrix.pkgs }} cmake git gtest pcre2-devel pkgconfig \
             'pkgconfig(libbrotlicommon)' 'pkgconfig(liblz4)' \
             'pkgconfig(libunwind-generic)' \
             'pkgconfig(libzstd)' 'pkgconfig(protobuf)' ninja tar xz zlib-devel
@@ -110,7 +102,7 @@ jobs:
         if: startsWith(matrix.os, 'archlinux')
         run: |
           pacman -Syu --needed --noconfirm \
-            ${{ matrix.pkgs }} brotli cmake git go gtest libunwind \
+            ${{ matrix.pkgs }} brotli cmake git gtest libunwind \
             lz4 pcre2 pkgconfig protobuf zstd ninja
 
       - name: prep ubuntu
@@ -118,7 +110,7 @@ jobs:
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-            ${{ matrix.pkgs }} cmake git golang libbrotli-dev \
+            ${{ matrix.pkgs }} cmake git libbrotli-dev \
             libgtest-dev liblz4-dev libpcre2-dev libprotobuf-dev libunwind-dev \
             libzstd-dev pkg-config protobuf-compiler ninja-build xz-utils
 
@@ -126,12 +118,12 @@ jobs:
         if: startsWith(matrix.os, 'alpine')
         run: |
           apk add build-base pcre2-dev linux-headers gtest-dev samurai \
-          go git perl cmake protobuf-dev brotli-dev zstd-dev lz4-dev
+          git perl cmake protobuf-dev brotli-dev zstd-dev lz4-dev
 
       - name: prep fedora
         if: startsWith(matrix.os, 'fedora')
         run: |
-          dnf install -y ${{ matrix.pkgs }} cmake ninja-build perl git golang \
+          dnf install -y ${{ matrix.pkgs }} cmake ninja-build perl git \
           brotli-devel gtest-devel lz4-devel pcre2-devel protobuf-devel \
           libzstd-devel tar xz
 
@@ -142,7 +134,6 @@ jobs:
 
       - name: build & install
         run: |
-          export GOFLAGS="-mod=vendor"
           tar -xf android-tools-*.tar.xz
           cd android-tools-*/
           test -n "${{ matrix.env1 }}" && export ${{ matrix.env1 }}
@@ -186,7 +177,7 @@ jobs:
       - name: prep macos
         run: |
           rm -rf /opt/homebrew/include/openssl /usr/local/opt/openssl /usr/local/include/openssl
-          brew install --overwrite --quiet brotli cmake go googletest lz4 \
+          brew install --overwrite --quiet brotli cmake googletest lz4 \
           ninja pcre2 protobuf zstd
 
       - name: download source

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         if: startsWith(matrix.os, 'opensuse')
         run: |
           zypper -n ref
-          zypper -n in ${{ matrix.pkgs }} cmake git gtest pcre2-devel pkgconfig \
+          zypper -n in ${{ matrix.pkgs }} cmake gtest pcre2-devel pkgconfig \
             'pkgconfig(libbrotlicommon)' 'pkgconfig(liblz4)' \
             'pkgconfig(libunwind-generic)' \
             'pkgconfig(libzstd)' 'pkgconfig(protobuf)' ninja tar xz zlib-devel
@@ -102,7 +102,7 @@ jobs:
         if: startsWith(matrix.os, 'archlinux')
         run: |
           pacman -Syu --needed --noconfirm \
-            ${{ matrix.pkgs }} brotli cmake git gtest libunwind \
+            ${{ matrix.pkgs }} brotli cmake gtest libunwind \
             lz4 pcre2 pkgconfig protobuf zstd ninja
 
       - name: prep ubuntu
@@ -110,7 +110,7 @@ jobs:
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-            ${{ matrix.pkgs }} cmake git libbrotli-dev \
+            ${{ matrix.pkgs }} cmake libbrotli-dev \
             libgtest-dev liblz4-dev libpcre2-dev libprotobuf-dev libunwind-dev \
             libzstd-dev pkg-config protobuf-compiler ninja-build xz-utils
 
@@ -118,12 +118,12 @@ jobs:
         if: startsWith(matrix.os, 'alpine')
         run: |
           apk add build-base pcre2-dev linux-headers gtest-dev samurai \
-          git perl cmake protobuf-dev brotli-dev zstd-dev lz4-dev
+          cmake protobuf-dev brotli-dev zstd-dev lz4-dev
 
       - name: prep fedora
         if: startsWith(matrix.os, 'fedora')
         run: |
-          dnf install -y ${{ matrix.pkgs }} cmake ninja-build perl git \
+          dnf install -y ${{ matrix.pkgs }} cmake ninja-build \
           brotli-devel gtest-devel lz4-devel pcre2-devel protobuf-devel \
           libzstd-devel tar xz
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Additionally the following software is required at compile-time:
 
 1. A C and C++ compiler (either [GCC][gcc] >= 10.X or [clang][clang])
 2. [CMake][cmake]
-3. [Perl][perl]
 
 *Currently the build system doesn't check whether all of these are installed.*
 
@@ -109,7 +108,6 @@ have been copied from Anatol's ruby script.
 [gcc]: https://gcc.gnu.org/
 [clang]: https://clang.llvm.org/
 [cmake]: https://cmake.org/
-[perl]: https://www.perl.org/
 [protobuf]: https://github.com/protocolbuffers/protobuf
 [brotli]: https://github.com/google/brotli
 [zstd]: https://facebook.github.io/zstd/

--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ are all written in Python.
 Additionally the following software is required at compile-time:
 
 1. A C and C++ compiler (either [GCC][gcc] >= 10.X or [clang][clang])
-2. The [Go compiler][golang]
-3. [CMake][cmake]
-4. [Perl][perl]
+2. [CMake][cmake]
+3. [Perl][perl]
 
 *Currently the build system doesn't check whether all of these are installed.*
 
@@ -109,7 +108,6 @@ have been copied from Anatol's ruby script.
 [gtest]: https://github.com/google/googletest
 [gcc]: https://gcc.gnu.org/
 [clang]: https://clang.llvm.org/
-[golang]: https://go.dev/
 [cmake]: https://cmake.org/
 [perl]: https://www.perl.org/
 [protobuf]: https://github.com/protocolbuffers/protobuf


### PR DESCRIPTION
golang is not required anymore for boringssl. This reverts some of the changes from 46ec7ccfb71c21ea116e1562a5848112915f7b78 and 1e417cc26f8c74daa5c96d5e11cdaa12a36063f0 commits.

* Fixes: https://github.com/nmeum/android-tools/issues/182