### PR TITLE
cmake: Disable and remove boringssl tests from source archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_subdirectory(vendor)
 set(CPACK_SOURCE_GENERATOR "TXZ")
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${PROJECT_NAME}-${ANDROID_VERSION}")
 set(CPACK_SOURCE_IGNORE_FILES "/patches/" "/build/" "/.git/" "/.github/" "/tests/"
-	"/testdata/" "/extras/simpleperf/scripts/" "/extras/simpleperf/demo/"
+	"/test/" "/testdata/" "/extras/simpleperf/scripts/" "/extras/simpleperf/demo/"
 	"aes_128_gcm.txt" "aes_256_gcm.txt"
 	"/fuzz/"
 	"/wycheproof_testvectors/"

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -75,6 +75,7 @@ if(ANDROID_TOOLS_PATCH_VENDOR AND EXISTS "${ANDROID_PATCH_DIR}/")
 	endforeach(v)
 endif()
 
+set(BUILD_TESTING OFF CACHE BOOL "Enable building tests")
 add_subdirectory(boringssl EXCLUDE_FROM_ALL)
 
 if(ANDROID_TOOLS_USE_BUNDLED_FMT)


### PR DESCRIPTION
Tests are not built but included in boringssl cmake. Also, those are golang files but go was removed already.