### PR TITLE
patches: Remove sys/cdefs.h header dependency

### DIFF
--- a/patches/libbase/0006-Fix-compilation-on-musl.patch
+++ b/patches/libbase/0006-Fix-compilation-on-musl.patch
@@ -1,0 +1,68 @@
+From fa9d61d6f01dea4123d85e2195cc49842ad9fcd1 Mon Sep 17 00:00:00 2001
+From: meator <meator.dev@gmail.com>
+Date: Mon, 10 Aug 2026 16:16:39 +0200
+Subject: [PATCH] Fix compilation on musl
+
+sys/cdefs.h is a nonstandard header that generally should not be
+included. musl systems normally do not provide it, but Alpine CI runners
+transitively pull in the bsd-compat-headers package, which provides a
+small sys/cdefs.h replacement header for misbehaving programs which
+still want to include this header.
+
+The comment above this include indicates that this header is used only
+to pull in the __BIONIC__ macro on systems using the Android Bionic C
+library. libbase is Google's library for common code shared between
+several of their projects and platforms, so it makes sense that they
+would include such platform dependent logic.
+
+But it doesn't really make sense to build android-tools using the
+Android NDK for android, it is an assortment of client programs meant
+for computers. There are likely a bunch of other things that would break
+if android-tools was compiled and used for Android targets.
+
+Removing the header leads to __BIONIC__ not being defined, which is
+correct. Even for systems where sys/cdefs.h would be pulled in (glibc),
+the behavior would be the same, since android-tools won't be built on
+Bionic.
+
+I have checked test_utils.cpp, the source file including test_utils.h
+and the header file itself and it seems that sys/cdefs.h is truly
+included for __BIONIC__ only, no other features of sys/cdefs.h are used
+in the code so it is safe to remove this include. This may theoretically
+change in the future as android-tools updates pull in newer libbase, but
+I find that unlikely.
+
+Alternative solution (instead of this patch):
+
+Tell the build system to look for __BIONIC__ macro in sys/cdefs.h. If it
+finds it, make it define ANDROID_TOOLS_BIONIC or a similarly named
+macro, which will then be used in place of __BIONIC__ in test_utils.cpp,
+include/android-base/test_utils.h and other files which might need it.
+The build system should not define __BIONIC__ directly to avoid
+conflicts on Android systems. This means that the two files will have
+to be patched to replace __BIONIC__ with ANDROID_TOOLS_BIONIC.
+
+If the build system does not find __BIONIC__ defined in sys/cdefs.h or
+if the build system does not find the sys/cdefs.h header file, it should
+simply do nothing (mainly it should not define ANDROID_TOOLS_BIONIC).
+---
+ include/android-base/test_utils.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/include/android-base/test_utils.h b/include/android-base/test_utils.h
+index e57138f..1e3cfc6 100644
+--- a/include/android-base/test_utils.h
++++ b/include/android-base/test_utils.h
+@@ -16,9 +16,6 @@
+ 
+ #pragma once
+ 
+-// For __BIONIC__
+-#include <sys/cdefs.h>
+-
+ #if defined(__BIONIC__)
+ #include <malloc.h>
+ #include <stdio.h>
+-- 
+2.55.0
+


### PR DESCRIPTION
Please see the description of the patch I added for an in length explanation.

Most distros dealing with musl already have a way around this. For example Alpine has the `bsd-compat-headers` and Chimera Linux has `musl-bsd-headers`, which provide a small simple `sys/cdefs.h` replacement. But it is a hack. Alpine's header even `#warning`s its users that it should not be included.

I have faced issues while trying to cross compile [my fork](https://github.com/meator/android-tools-static) on musl, since the target environment does not have `sys/cdefs.h`. I'm fairly certain that the same issue can occur in nmeum/android-tools, but it is a pain to cross compile nmeum/android-tools, I didn't want to cross compile all of its dependencies so I have not tested this.

Alternative solutions include:
- do nothing, musl users will have to install `bsd-compat-headers` or an equivalent package (which might sometimes be pulled in transitively, as it is pulled in Alpine CI)

  Cross sysroots will have to have `sys/cdefs.h` available too, which isn't mandatory and for example [musl-cross-make](https://github.com/richfelker/musl-cross-make), which is used by my fork, does not provide this header (since musl doesn't provide it).
- vendor a `sys/cdefs.h` file

  Theoretically, overriding this project-wide and vendoring an empty file should work fine. A more targetted solution would be adding this to include path only where it's needed (`libbase/test_utils.cpp` of `libbase`) and vendoring a `sys/cdefs.h` which has at least some of the stuff its users would expect (Chimera's would be a good pick).

  But if what I've written in the patch description is correct, `sys/cdefs.h` is only needed for potential `__BIONIC__` macro definition, so an empty header file should be sufficient.
  
  <details><summary>Chimera's cdefs.h suitable for vendoring</summary>
  <p>

  ```c
  #ifndef _SYS_CDEFS_H_
  #define _SYS_CDEFS_H_

  #undef __P
  #undef __PMT

  #define __P(args)	args
  #define __PMT(args)	args

  #define __CONCAT(x,y)	x ## y
  #define __STRING(x)	#x

  #ifdef  __cplusplus
  # define __BEGIN_DECLS	extern "C" {
  # define __END_DECLS	}
  #else
  # define __BEGIN_DECLS
  # define __END_DECLS
  #endif

  #if defined(__GNUC__) && !defined(__cplusplus)
  # define __THROW	__attribute__ ((__nothrow__))
  # define __NTH(fct)	__attribute__ ((__nothrow__)) fct
  #else
  # define __THROW
  # define __NTH(fct)     fct
  #endif

  #define __CONCAT(x,y)   x ## y
  #define __STRING(x)     #x

  #endif /* _SYS_CDEFS_H_ */
  ```

  </p>
  </details>
- do `__BIONIC__` detection in CMake instead of in the header

  This solution is described in the patch description.

This is a 37.0.0 issue, 36.0.1 and earlier did not use `sys/cdefs.h`.