### PR TITLE
cmake: Remove useless cpp from target

### DIFF
--- a/vendor/CMakeLists.libbase.txt
+++ b/vendor/CMakeLists.libbase.txt
@@ -14,7 +14,6 @@ add_library(libbase STATIC
     libbase/stringprintf.cpp
     libbase/strings.cpp
     libbase/threads.cpp
-    libbase/test_utils.cpp
     libbase/errors_unix.cpp)
 
 target_include_directories(libbase PUBLIC


### PR DESCRIPTION
See https://github.com/nmeum/android-tools/pull/210 for discussion.

This is blocking my fork's 37.0.0 update, so I want to get this over with.